### PR TITLE
Types translation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,4 @@ docker run --rm -e S3_BUCKET=s3://dlme-metadata-development \
 ```
 Note that actual S3 credentials are available from `shared_configs`.
 
-### Readers and Writers
-
-Traject uses modular 'Writer' classes to take the output hashes from transformation and send them somewhere or do something useful with them.
-
-By default traject uses the Traject::SolrJsonWriter (rdoc) to send to Solr for indexing. Several other writers are also built-in:
-
-* Traject::DebugWriter (rdoc)
-* Traject::JsonWriter (rdoc)
-* Traject::YamlWriter (rdoc)
-* Traject::DelimitedWriter (rdoc)
-* Traject::CSVWriter (rdoc)
-
-You set which writer is being used in settings (provide "writer_class_name", "Traject::DebugWriter"), or with the shortcut command line argument -w Traject::DebugWriter.
-
-The SolrJWriter is packaged separately, and will be useful if you need to index to Solr's older than version 3.2. It requires Jruby.
-
+For more information on traject, [read the documentation](https://github.com/traject/traject#Traject)

--- a/README.md
+++ b/README.md
@@ -69,3 +69,20 @@ docker run --rm -e S3_BUCKET=s3://dlme-metadata-development \
                 dlme-metadata/stanford/maps/data/kj751hs0595.mods
 ```
 Note that actual S3 credentials are available from `shared_configs`.
+
+### Readers and Writers
+
+Traject uses modular 'Writer' classes to take the output hashes from transformation and send them somewhere or do something useful with them.
+
+By default traject uses the Traject::SolrJsonWriter (rdoc) to send to Solr for indexing. Several other writers are also built-in:
+
+* Traject::DebugWriter (rdoc)
+* Traject::JsonWriter (rdoc)
+* Traject::YamlWriter (rdoc)
+* Traject::DelimitedWriter (rdoc)
+* Traject::CSVWriter (rdoc)
+
+You set which writer is being used in settings (provide "writer_class_name", "Traject::DebugWriter"), or with the shortcut command line argument -w Traject::DebugWriter.
+
+The SolrJWriter is packaged separately, and will be useful if you need to index to Solr's older than version 3.2. It requires Jruby.
+

--- a/lib/translation_maps/edm_types.yaml
+++ b/lib/translation_maps/edm_types.yaml
@@ -3,20 +3,22 @@
 3d: 3d
 artifact: image
 audio: sound
-cartographic: cartographic
-collection: collection
-dataset: dataset
-digital data: dataset
+# cartographic: cartographic
+cartographic: image
+# collection: collection
+# dataset: dataset
+# digital data: dataset
 image: image
-interactive resource: interactive resource
+# interactive resource: interactive resource
 manuscript: text
-map: cartographic
-mixed material: text
+# map: cartographic
+map: image
+# mixed material: text
 moving image: video
-multimedia: [sound, video]
+# multimedia: [sound, video]
 notated music: text
-software: software
-software, multimedia: software
+# software: software
+# software, multimedia: software
 sound: sound
 sound recording: sound
 sound recording-musical: sound
@@ -26,19 +28,21 @@ stillimage: image
 tactile: image
 text: text
 three dimensional object: image
-vector digital data: dataset
+# vector digital data: dataset
 video: video
 # MARC types
 a: text
 c: text
 d: text
-e: cartographic
-f: cartographic
+# e: cartographic
+# f: cartographic
+e: image
+f: image
 g: image
 i: sound
 j: sound
 k: image
-m: software
+# m: software
 p: text
 r: image
 t: text


### PR DESCRIPTION
This can start our discussion about changing the translation map to align with the [application profile](https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md). It makes sense to me to keep the cho_edm_type simple and use the cho_type to try to add nuance. The name change will break the config scripts that call the translation_map but we need to revise them anyway https://github.com/sul-dlss/dlme-metadata/issues/29 so we can hold off on merging until those are revised. I think the naming will hopefully avoid confusion going forward.