### PR TITLE
align types with application profile

### DIFF
--- a/lib/translation_maps/edm_types.yaml
+++ b/lib/translation_maps/edm_types.yaml
@@ -3,20 +3,22 @@
 3d: 3d
 artifact: image
 audio: sound
-cartographic: cartographic
-collection: collection
-dataset: dataset
-digital data: dataset
+# cartographic: cartographic
+cartographic: image
+# collection: collection
+# dataset: dataset
+# digital data: dataset
 image: image
-interactive resource: interactive resource
+# interactive resource: interactive resource
 manuscript: text
-map: cartographic
-mixed material: text
+# map: cartographic
+map: image
+# mixed material: text
 moving image: video
-multimedia: [sound, video]
+# multimedia: [sound, video]
 notated music: text
-software: software
-software, multimedia: software
+# software: software
+# software, multimedia: software
 sound: sound
 sound recording: sound
 sound recording-musical: sound
@@ -26,19 +28,21 @@ stillimage: image
 tactile: image
 text: text
 three dimensional object: image
-vector digital data: dataset
+# vector digital data: dataset
 video: video
 # MARC types
 a: text
 c: text
 d: text
-e: cartographic
-f: cartographic
+# e: cartographic
+# f: cartographic
+e: image
+f: image
 g: image
 i: sound
 j: sound
 k: image
-m: software
+# m: software
 p: text
 r: image
 t: text

--- a/spec/lib/traject/macros/extraction_spec.rb
+++ b/spec/lib/traject/macros/extraction_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Macros::Extraction do
     end
 
     describe '#translation_map' do
-      let(:options) { { translation_map: 'types' } }
+      let(:options) { { translation_map: 'edm_types' } }
 
       it 'looks up a value from the translation map' do
         expect(pipeline.transform(['audio'])).to eq ['sound']


### PR DESCRIPTION
This can start our conversation about aligning the types translation map with the [application profile](https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md). The name change will break config files that call it but we need to update those anyway so we can hold off on merging until https://github.com/sul-dlss/dlme-metadata/issues/29 is complete. 