### PR TITLE
Rescue StandardError rather than RuntimeError

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -55,6 +55,8 @@ module Dlme
       rescue StandardError => e
         warn "[ERROR] #{e.message}"
         write_summary(error: e.message)
+        raise e unless e < RuntimeError
+
         exit(1)
       end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -52,7 +52,7 @@ module Dlme
         @start = Time.now
         transform_all
         write_summary
-      rescue RuntimeError => e
+      rescue StandardError => e
         warn "[ERROR] #{e.message}"
         write_summary(error: e.message)
         exit(1)


### PR DESCRIPTION
StandardError is broader and encompases things like TypeError

Fixes #99