### PR TITLE
add values found in auc to translation maps

### DIFF
--- a/lib/translation_maps/languages.yaml
+++ b/lib/translation_maps/languages.yaml
@@ -205,3 +205,7 @@ slovakça: Slovak
 türkçe: Turkish
 türkçe-osmanlıca: Turkish, Ottoman
 yunanca: Greek
+
+# Errors: map to nothing to pass not_found test
+eg:
+englishglish:

--- a/lib/translation_maps/types.yaml
+++ b/lib/translation_maps/types.yaml
@@ -13,6 +13,7 @@ manuscript: text
 map: image
 mixed material: text
 moving image: video
+moving images: video
 multimedia: [sound, video]
 notated music: text
 software: interactive resource


### PR DESCRIPTION
Let me know if you have other thoughts on how to deal with errors in the metadata. I found `eg` and `englishglish` for language and mapped them to nothing so I could get past the not_found test. `englishglish` clearly means English but that was already added so removing `englishglish` won't take 'English' out in this case