### PR TITLE
add translation map for french types

### DIFF
--- a/lib/translation_maps/french-types.yaml
+++ b/lib/translation_maps/french-types.yaml
@@ -1,0 +1,2 @@
+# French langauge types
+image fixe: image


### PR DESCRIPTION
Found some errors in the type field that were coming from the bnf data. While I was fixing them it made sense to break out the french type fields into a separate translation map instead of using default('image') to fix the problem.