### PR TITLE
Pin TrajectPlus to 1.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,15 @@ gem 'activesupport', '~> 5.2'
 gem 'dry-schema'
 gem 'faraday'
 gem 'thor', '~> 0.20'
-gem 'traject_plus', '~> 1.1'
+# Pin traject_plus to 1.1.0 because 1.2.0 causes errors:
+#
+# [ERROR] Error loading configuration file config/mods_config.rb:11
+# NoMethodError:undefined method `extended' for #<Traject::Indexer:0x0000564b796c1bd0>
+# Did you mean? extend
+# /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:231:in `rescue in block in load_config_file': ...
+#
+# Pin back to '~> 1.2' when https://github.com/sul-dlss/traject_plus/issues/33 is closed
+gem 'traject_plus', '~> 1.1.0'
 
 group :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       nokogiri (~> 1.9)
       slop (>= 3.4.5, < 4.0)
       yell
-    traject_plus (1.2.0)
+    traject_plus (1.1.1)
       activesupport
       deprecation
       jsonpath
@@ -168,7 +168,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.21.0)
   simplecov
   thor (~> 0.20)
-  traject_plus (~> 1.1)
+  traject_plus (~> 1.1.0)
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
## Why was this change made?

A recent bump to TrajectPlus 1.2.0 is causing errors when transforming data:

```
[ERROR] Error loading configuration file config/mods_config.rb:11
NoMethodError:undefined method `extended' for #<Traject::Indexer:0x0000564b796c1bd0>
Did you mean? extend
/usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:231:in `rescue in block in load_config_file': ...
```

Once https://github.com/sul-dlss/traject_plus/issues/33 is closed, we can revert
this PR and/or update TrajectPlus again.

## Was the documentation (README, API, wiki, ...) updated?

N/A