### PR TITLE
Use TrajectPlus 1.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       nokogiri (~> 1.9)
       slop (>= 3.4.5, < 4.0)
       yell
-    traject_plus (1.2.1)
+    traject_plus (1.2.2)
       activesupport
       deprecation
       jsonpath


### PR DESCRIPTION
## Why was this change made?

Use this instead of TrajectPlus 1.2.0 or 1.2.1, both of which contained breaking changes (in the context of our Traject configs in `dlme-traject`).

## Was the documentation (README, API, wiki, ...) updated?

No.