### PR TITLE
Bump TrajectPlus to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'dry-schema'
 gem 'faraday'
 gem 'thor', '~> 0.20'
-gem 'traject_plus', '~> 1.2'
+gem 'traject_plus', '~> 1.3'
 
 group :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       nokogiri (~> 1.9)
       slop (>= 3.4.5, < 4.0)
       yell
-    traject_plus (1.2.1)
+    traject_plus (1.3.0)
       activesupport
       deprecation
       jsonpath
@@ -168,7 +168,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.21.0)
   simplecov
   thor (~> 0.20)
-  traject_plus (~> 1.2)
+  traject_plus (~> 1.3)
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
## Why was this change made?

To use the correct version. (1.2.2 should have been 1.3.0.)

## Was the documentation (README, API, wiki, ...) updated?

no