### PR TITLE
tei macro: penn_thumbnail url might be missing

### DIFF
--- a/lib/macros/tei.rb
+++ b/lib/macros/tei.rb
@@ -63,9 +63,9 @@ module Macros
         thumb_xpath = record.xpath("/*/tei:facsimile/tei:surface[@n='2r']/tei:graphic[2]/@url", NS).map(&:text)
                             .first
         ending = "/data/#{thumb_xpath}"
-        accumulator << record.xpath('/*/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'\
-          "/tei:msIdentifier/tei:altIdentifier[@type='openn-url']/tei:idno", NS).map(&:text).first.gsub('/html', '')
-                             .gsub('.html', ending)
+        url_node_set = record.xpath('/*/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'\
+                           "/tei:msIdentifier/tei:altIdentifier[@type='openn-url']/tei:idno", NS)
+        accumulator << url_node_set.map(&:text).first.gsub('/html', '').gsub('.html', ending) if url_node_set.present?
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

#### Running the penn dataset with 

```
docker run --rm -e SKIP_FETCH_CONFIG=true -e SKIP_FETCH_DATA=true -v $(pwd)/.:/opt/traject -v $(pwd)/../dlme-traject:/opt/traject/config -v $(pwd)/../dlme-metadata:/opt/traject/data -v $(pwd)/output:/opt/traject/output suldlss/dlme-transform:latest penn
```

#### was giving errors:

```
2019-09-26T20:41:40+00:00  INFO    Traject::Indexer with 1 processing threads, reader: TrajectPlus::XmlReader and writer: DlmeJsonResourceWriter
2019-09-26T20:41:40+00:00 ERROR Unexpected error on record <record #1 (data/penn/schoenberg/data/schoenberg-189.xml #1), output_id:penn_schoenberg-189>
    while executing (to_field "agg_preview" at config/tei_config.rb:36)

    Record: <?xml version="1.0" encoding="UTF-8"?>
<TEI xmlns="http://www.tei-c.org/ns/1.0">
... snip ...
</TEI>

    Exception: NoMethodError: undefined method `gsub' for nil:NilClass
    /opt/traject/lib/macros/tei.rb:68:in `block in penn_thumbnail'

[ERROR] undefined method `gsub' for nil:NilClass
/opt/traject/lib/macros/tei.rb:68:in `block in penn_thumbnail': undefined method `gsub' for nil:NilClass (NoMethodError)
	from /usr/local/bundle/gems/traject_plus-1.3.0/lib/traject_plus/macros.rb:15:in `block (2 levels) in transform_values'
	from /usr/local/bundle/gems/traject_plus-1.3.0/lib/traject_plus/macros.rb:13:in `each'
	from /usr/local/bundle/gems/traject_plus-1.3.0/lib/traject_plus/macros.rb:13:in `block in transform_values'
	from /usr/local/bundle/gems/traject_plus-1.3.0/lib/traject_plus/macros.rb:11:in `transform_values'
	from /usr/local/bundle/gems/traject_plus-1.3.0/lib/traject_plus/macros.rb:11:in `transform_values'
	from config/tei_config.rb:37:in `block (2 levels) in load_config_file'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer/step.rb:140:in `block in execute'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer/step.rb:135:in `each'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer/step.rb:135:in `execute'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:464:in `block (2 levels) in map_to_context!'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:504:in `handle_mapping_errors'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:463:in `block in map_to_context!'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:457:in `each'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:457:in `map_to_context!'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:582:in `block (3 levels) in process'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/thread_pool.rb:123:in `block in maybe_in_thread_pool'
	from /usr/local/bundle/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:348:in `run_task'
```

## Was the documentation (README, API, wiki, ...) updated?

n/a