### PR TITLE
mechanism changed for extending Traject macros

### DIFF
--- a/lib/macros/aims.rb
+++ b/lib/macros/aims.rb
@@ -17,9 +17,7 @@ module Macros
     PREFIX = 'item/'
     private_constant :PREFIX
 
-    def self.extended(mod)
-      mod.extend Traject::Macros::NokogiriMacros
-    end
+    include Traject::Macros::NokogiriMacros
 
     # Extracts values for the given xpath
     # @example

--- a/lib/macros/harvard.rb
+++ b/lib/macros/harvard.rb
@@ -8,9 +8,7 @@ module Macros
     }.freeze
     private_constant :NS
 
-    def self.extended(mod)
-      mod.extend Traject::Macros::NokogiriMacros
-    end
+    include Traject::Macros::NokogiriMacros
 
     # Extracts values for the given xpath which is prefixed with dc wrappers
     # @example

--- a/lib/macros/oai.rb
+++ b/lib/macros/oai.rb
@@ -13,9 +13,7 @@ module Macros
     PREFIX = '/oai:record/oai:metadata/oai_dc:dc/'
     private_constant :PREFIX
 
-    def self.extended(mod)
-      mod.extend Traject::Macros::NokogiriMacros
-    end
+    include Traject::Macros::NokogiriMacros
 
     # Extracts values for the given xpath which is prefixed with oai and oai_dc wrappers
     # @example

--- a/lib/macros/qnl.rb
+++ b/lib/macros/qnl.rb
@@ -12,9 +12,7 @@ module Macros
     PREFIX = '/oai:record/oai:metadata/mods:mods/'
     private_constant :PREFIX
 
-    def self.extended(mod)
-      mod.extend Traject::Macros::NokogiriMacros
-    end
+    include Traject::Macros::NokogiriMacros
 
     # Extracts values for the given xpath which is prefixed with oai and mods wrappers
     # @example

--- a/lib/macros/srw.rb
+++ b/lib/macros/srw.rb
@@ -15,9 +15,7 @@ module Macros
     EXTRA_PREFIX = 'srw:record/srw:extraRecordData/'
     private_constant :EXTRA_PREFIX
 
-    def self.extended(mod)
-      mod.extend Traject::Macros::NokogiriMacros
-    end
+    include Traject::Macros::NokogiriMacros
 
     # Extracts values for the given xpath which is prefixed with srw and oai wrappers
     # @param [String] xpath the xpath query expression

--- a/lib/macros/tei.rb
+++ b/lib/macros/tei.rb
@@ -9,9 +9,7 @@ module Macros
     }.freeze
     private_constant :NS
 
-    def self.extended(mod)
-      mod.extend Traject::Macros::NokogiriMacros
-    end
+    include Traject::Macros::NokogiriMacros
 
     # Returns the data provider value from the repository and institution values in the TEI XML.
     # @return [Proc] a proc that traject can call for each record


### PR DESCRIPTION
## Why was this change made?

Based on what @mjgiarlo did in sul-dlss/traject_plus/pull/34, this seems necessary (?).

## Was the documentation (README, API, wiki, ...) updated?

n/a