### PR TITLE
rename method to avoid future confusion

### DIFF
--- a/lib/macros/tei.rb
+++ b/lib/macros/tei.rb
@@ -58,7 +58,7 @@ module Macros
     end
 
     # @return [String] an xpath for a thumbnail image
-    def penn_thumbnail
+    def openn_thumbnail
       lambda do |record, accumulator|
         thumb_xpath = record.xpath("/*/tei:facsimile/tei:surface[@n='2r']/tei:graphic[2]/@url", NS).map(&:text)
                             .first


### PR DESCRIPTION
## Why was this change made?
The method only works on the penn/openn data; the name will avoid future confusion. Accompanying changes in dlme-traject are on the way.

## Was the documentation (README, API, wiki, ...) updated?
Not applicable