### PR TITLE
dlme_json_schema: some fixes from upgrade to dry-schema gem

### DIFF
--- a/lib/dlme_json_schema.rb
+++ b/lib/dlme_json_schema.rb
@@ -7,57 +7,57 @@ require 'dry-schema'
 # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#svcsservice
 ServicesSchema = Dry::Schema.JSON do
   required(:service_id).filled(:string)
-  required(:service_conforms_to) { array? { each(:str?) } }
+  required(:service_conforms_to).array(:str?)
   optional(:service_implements).filled(:string)
 end
 
 # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#edmwebresource
 EDMWebResourceSchema = Dry::Schema.JSON do
   required(:wr_id).filled(:string)
-  optional(:wr_format) { array? { each(:str?) } }
-  optional(:wr_has_service).each do
+  optional(:wr_format).array(:str?)
+  optional(:wr_has_service).value(:array).each do
     schema(ServicesSchema)
   end
 end
 
 DlmeJsonSchema = Dry::Schema.JSON do
   # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#edmprovidedcho
-  optional(:cho_alternative) { array? { each(:str?) } }
-  optional(:cho_contributor) { array? { each(:str?) } }
-  optional(:cho_coverage) { array? { each(:str?) } }
-  optional(:cho_creator) { array? { each(:str?) } }
-  optional(:cho_date) { array? { each(:str?) } }
-  optional(:cho_dc_rights) { array? { each(:str?) } }
-  optional(:cho_description) { array? { each(:str?) } }
+  optional(:cho_alternative).array(:str?)
+  optional(:cho_contributor).array(:str?)
+  optional(:cho_coverage).array(:str?)
+  optional(:cho_creator).array(:str?)
+  optional(:cho_date).array(:str?)
+  optional(:cho_dc_rights).array(:str?)
+  optional(:cho_description).array(:str?)
   optional(:cho_edm_type) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }
-  optional(:cho_extent) { array? { each(:str?) } }
-  optional(:cho_format) { array? { each(:str?) } }
-  optional(:cho_has_part) { array? { each(:str?) } }
-  optional(:cho_has_type) { array? { each(:str?) } }
-  optional(:cho_identifier) { array? { each(:str?) } }
-  optional(:cho_is_part_of) { array? { each(:str?) } }
+  optional(:cho_extent).array(:str?)
+  optional(:cho_format).array(:str?)
+  optional(:cho_has_part).array(:str?)
+  optional(:cho_has_type).array(:str?)
+  optional(:cho_identifier).array(:str?)
+  optional(:cho_is_part_of).array(:str?)
   optional(:cho_language) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }
-  optional(:cho_medium) { array? { each(:str?) } }
-  optional(:cho_provenance) { array? { each(:str?) } }
-  optional(:cho_publisher) { array? { each(:str?) } }
-  optional(:cho_relation) { array? { each(:str?) } }
-  optional(:cho_same_as) { array? { each(:str?) } }
-  optional(:cho_source) { array? { each(:str?) } }
-  optional(:cho_spatial) { array? { each(:str?) } }
-  optional(:cho_subject) { array? { each(:str?) } }
-  optional(:cho_temporal) { array? { each(:str?) } }
-  required(:cho_title) { array? { each(:str?) } }
-  optional(:cho_type) { array? { each(:str?) } }
+  optional(:cho_medium).array(:str?)
+  optional(:cho_provenance).array(:str?)
+  optional(:cho_publisher).array(:str?)
+  optional(:cho_relation).array(:str?)
+  optional(:cho_same_as).array(:str?)
+  optional(:cho_source).array(:str?)
+  optional(:cho_spatial).array(:str?)
+  optional(:cho_subject).array(:str?)
+  optional(:cho_temporal).array(:str?)
+  required(:cho_title).array(:str?)
+  optional(:cho_type).array(:str?)
 
   # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#oreaggregation
   required(:id).filled(:string)
   optional('__source'.to_sym).filled(:string)
   # Since the IR is a flattened projection of the MAP, 'agg_aggregated_cho' is not used.
   required(:agg_data_provider).filled(:string)
-  optional(:agg_dc_rights) { array? { each(:str?) } }
-  optional(:agg_edm_rights) { array? { each(:str?) } } # At least one is required
+  optional(:agg_dc_rights).array(:str?)
+  optional(:agg_edm_rights).array(:str?) # At least one is required
 
-  optional(:agg_has_view).each do # 0 to n
+  optional(:agg_has_view).value(:array) do # 0 to n
     schema(EDMWebResourceSchema)
   end
 
@@ -66,6 +66,6 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional(:agg_preview).schema(EDMWebResourceSchema) # 0 or 1
 
   required(:agg_provider).filled(:string)
-  optional(:agg_same_as) { array? { each(:str?) } } # reference
+  optional(:agg_same_as).array(:str?) # reference
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Why was this change made?

#### stanford data was getting these dry-schema errors:

```
[ERROR] Transform produced invalid data.

The errors are: [
#<Dry::Schema::Message text="is missing" path=[:agg_is_shown_by, :wr_has_service, 0, :service_id] predicate=:key? 
input={"service_conforms_to"=>["http://iiif.io/api/image/"], "service_id"=>"https://stacks.stanford.edu/image/iiif/cm881bj1960%2FW705_000001_300", "service_implements"=>"http://iiif.io/api/image/2/level2.json"}>, 

#<Dry::Schema::Message text="is missing" path=[:agg_is_shown_by, :wr_has_service, 0, :service_conforms_to] predicate=:key? 
input={"service_conforms_to"=>["http://iiif.io/api/image/"], "service_id"=>"https://stacks.stanford.edu/image/iiif/cm881bj1960%2FW705_000001_300", "service_implements"=>"http://iiif.io/api/image/2/level2.json"}>, 

#<Dry::Schema::Message text="is missing" path=[:agg_preview, :wr_has_service, 0, :service_id] predicate=:key? 
input={"service_conforms_to"=>["http://iiif.io/api/image/"], "service_id"=>"https://stacks.stanford.edu/image/iiif/cm881bj1960%2FW705_000001_300", "service_implements"=>"http://iiif.io/api/image/2/level2.json"}>, 

#<Dry::Schema::Message text="is missing" path=[:agg_preview, :wr_has_service, 0, :service_conforms_to] predicate=:key? 
input={"service_conforms_to"=>["http://iiif.io/api/image/"], "service_id"=>"https://stacks.stanford.edu/image/iiif/cm881bj1960%2FW705_000001_300", "service_implements"=>"http://iiif.io/api/image/2/level2.json"}>]}
```

#### This PR fixes the above
and also uses a more compact way to express "element x should be an array of string values (see "each" explained here:  https://dry-rb.org/gems/dry-schema/basics/macros/ )

Note that I'm not sure if "excluded_from" is correct in our schema now, but ... maybe???   Let's watch for those errors on xform.

## Was the documentation (README, API, wiki, ...) updated?

n/a
