### PR TITLE
closes #215

### DIFF
--- a/lib/macros/normalize.rb
+++ b/lib/macros/normalize.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Macros
+  # Macros for normalizing incoming metadata
+  module Normalize
+    # Extracts earliest & latest dates and merges into singe date range value
+    # @example
+    #   penn_museum_date_range => lambda { ... }
+    # @return [Proc] a proc that traject can call for each record
+    def penn_museum_date_range
+      lambda do |record, accumulator, _context|
+        accumulator << [record['date_made_early'], record['date_made_late']].select(&:present?).join('/').presence
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
Need to map an earliest date and latest date from separate incoming fields to a single `cho_date_norm` range. 

## Was the documentation (README, API, wiki, ...) updated?
Not applicable