### PR TITLE
Add cho_date_norm and cho_date_hijri to schema

### DIFF
--- a/lib/dlme_json_schema.rb
+++ b/lib/dlme_json_schema.rb
@@ -28,7 +28,7 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional(:cho_creator).array(:str?)
   optional(:cho_date).array(:str?)
   optional(:cho_date_hijri).array(:str?)
-  optional(:cho_date_norm).array(:integer) # this is an array of integers specificaly to capture the int representaiton of all years in a range
+  optional(:cho_date_norm).array(:integer) # this is an array of integers to capture the years in a range
   optional(:cho_dc_rights).array(:str?)
   optional(:cho_description).array(:str?)
   optional(:cho_edm_type) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }

--- a/lib/dlme_json_schema.rb
+++ b/lib/dlme_json_schema.rb
@@ -27,6 +27,8 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional(:cho_coverage).array(:str?)
   optional(:cho_creator).array(:str?)
   optional(:cho_date).array(:str?)
+  optional(:cho_date_hijri).array(:str?)
+  optional(:cho_date_norm).array(:integer) # this is an array of integers specificaly to capture the int representaiton of all years in a range
   optional(:cho_dc_rights).array(:str?)
   optional(:cho_description).array(:str?)
   optional(:cho_edm_type) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }

--- a/lib/dlme_json_schema.rb
+++ b/lib/dlme_json_schema.rb
@@ -28,7 +28,7 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional(:cho_creator).array(:str?)
   optional(:cho_date).array(:str?)
   optional(:cho_date_hijri).array(:str?)
-  optional(:cho_date_norm).array(:integer) # this is an array of integers to capture the years in a range
+  optional(:cho_date_range_norm).array(:integer) # this is an array of integers to capture the years in a range
   optional(:cho_dc_rights).array(:str?)
   optional(:cho_description).array(:str?)
   optional(:cho_edm_type) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }


### PR DESCRIPTION
## Why was this change made?

The IR requires a field for the conversion of dates into hijri dates. Additional we need an array to capture the integer representation of all individual years within a range.

## Was the documentation (README, API, wiki, ...) updated?

N/A