### PR TITLE
Update Arabic language values in translation map, closes #174

### DIFF
--- a/lib/translation_maps/norm_languages_to_ar.yaml
+++ b/lib/translation_maps/norm_languages_to_ar.yaml
@@ -1,19 +1,19 @@
-Arabic: عربى
-Hebrew: اللغة العبرية
-Judeo-Arabic: اليهودية العربية
-French: فرنسي
+Arabic: العربية
+Hebrew: العبرية
+Judeo-Arabic: العربية اليهودية
+French: الفرنسية
 English: الإنجليزية
-Official Aramaic (700-300 BCE): أرامين الرسمية (700-300) قبل الميلاد
-Turkish: اللغة التركية
-Persian: اللغة الفارسية
-Turkish, Ottoman (1500-1928): (التركية والعثمانية (1500-1928
-German: ألمانية
-Armenian: الأرميني
+Official Aramaic (700-300 BCE): (الآرامية الرسمية (من 700 إلى 300 قبل الميلاد
+Turkish: التركية
+Persian: الفارسية
+Turkish, Ottoman (1500-1928): (التركية العثمانية (من 1500 إلى 1928
+German: الألمانية
+Armenian: الأرمنية
 Coptic: القبطية
-Italian: الإيطالي
-Latin: لاتينية
+Italian: الإيطالية
+Latin: اللاتينية
 Indic Languages: اللغات الهندية
 Classical Syriac: السريانية الكلاسيكية
-Ladino: ادينو
-Greek, Pontic: بونتيك اليونانية
-Ancient Greek (to 1453): (اليونانية القديمة (حتى 1453
+Ladino: اللغة اللادينية
+Greek, Pontic: (اليونانية (البنطية
+Ancient Greek (to 1453): (اليونانية القديمة (حتى 1453 م


### PR DESCRIPTION
## Why was this change made?
Update the Arabic language values in the translation map based on feedback from Qatar National Library

## Was the documentation (README, API, wiki, ...) updated?
NA