### PR TITLE
Add agg_data_provider_country and agg_provider_country to adjust_card…

### DIFF
--- a/lib/adjust_cardinality.rb
+++ b/lib/adjust_cardinality.rb
@@ -21,7 +21,8 @@ class AdjustCardinality
   end
 
   def flatten_top_level(attributes)
-    flatten = %w[id agg_data_provider agg_data_provider_country agg_provider agg_provider_country agg_is_shown_at agg_is_shown_by agg_preview]
+    flatten = %w[id agg_data_provider agg_data_provider_country agg_provider agg_provider_country
+                 agg_is_shown_at agg_is_shown_by agg_preview]
     attributes.except(*flatten).tap do |output|
       flatten.each do |field|
         next unless attributes.key?(field)

--- a/lib/adjust_cardinality.rb
+++ b/lib/adjust_cardinality.rb
@@ -21,7 +21,7 @@ class AdjustCardinality
   end
 
   def flatten_top_level(attributes)
-    flatten = %w[id agg_data_provider agg_provider agg_is_shown_at agg_is_shown_by agg_preview]
+    flatten = %w[id agg_data_provider agg_data_provider_country agg_provider agg_provider_country agg_is_shown_at agg_is_shown_by agg_preview]
     attributes.except(*flatten).tap do |output|
       flatten.each do |field|
         next unless attributes.key?(field)


### PR DESCRIPTION
…inality

## Why was this change made?

Paired with https://github.com/sul-dlss/dlme-traject/pull/133, this Fixes #228 by removing the duplication into an array and adding `agg_provider_country` and `agg_data_provider_country` to `adjust_cardinality`.

Before:

```
   "agg_data_provider_country" : [
      "United States of America"
   "agg_provider_country" : [
      "United States of America"
   ],
```

After:

```
   "agg_provider_country" : "United States of America",
   "agg_data_provider_country" : "United States of America",
```

## Was the documentation (README, API, wiki, ...) updated?

N/A