### PR TITLE
add date_parsing macros

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ executors:
     - image: circleci/buildpack-deps:stretch
 jobs:
   test:
+    environment:
+      CC_TEST_REPORTER_ID: 25f90cb6d13d2dabb943971472fab94fe7eeb7595b7b4000296f1959b7ad13c5
     docker:
       - image: circleci/ruby:2.5.3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,146 +8,147 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.5.3
+      - image: circleci/ruby:2.5.3
     steps:
-    - checkout
+      - checkout
 
-    # Upgrade bundler
-    - run:
-        name: Install Bundler
-        command: gem install bundler
+      # Upgrade bundler
+      - run:
+          name: Install Bundler
+          command: gem install bundler
 
-    - run:
-        name: Which bundler?
-        command: bundle -v
+      - run:
+          name: Which bundler?
+          command: bundle -v
 
-    # Restore bundle cache
-    - restore_cache:
-        keys:
-        - app-bundle-v2-{{ checksum "Gemfile.lock" }}
-        - app-bundle-v2-
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+          - app-bundle-v2-{{ checksum "Gemfile.lock" }}
+          - app-bundle-v2-
 
-    - run:
-        name: Bundle Install
-        command: bundle check || bundle install
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
 
-    # Store bundle cache
-    - save_cache:
-        key: app-bundle-v2-{{ checksum "Gemfile.lock" }}
-        paths:
-        - vendor/bundle
+      # Store bundle cache
+      - save_cache:
+          key: app-bundle-v2-{{ checksum "Gemfile.lock" }}
+          paths:
+          - vendor/bundle
 
-    - run:
-        name: Check styles using rubocop
-        command: bundle exec rubocop
+      - run:
+          name: Check styles using rubocop
+          command: bundle exec rubocop
 
-    - run:
-        name: Setup Code Climate test-reporter
-        command: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
 
-    - run:
-        name: Run rspec tests
-        command: bundle exec rspec
+      - run:
+          name: Run rspec tests
+          command: bundle exec rspec
 
-    - run:
-        name: Send coverage report to Code Climate
-        command: |
-          ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
+      - run:
+          name: Send coverage report to Code Climate
+          command: |
+            ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
 
   build-image:
     executor: docker-publisher
     steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Build Docker image
-        command: |
-          docker build --build-arg VCS_REF=`git rev-parse --short HEAD` \
-                    --build-arg VCS_URL=`git config --get remote.origin.url` \
-                    --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-                    . -t $IMAGE_NAME:latest
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            docker build --build-arg VCS_REF=`git rev-parse --short HEAD` \
+                      --build-arg VCS_URL=`git config --get remote.origin.url` \
+                      --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+                      . -t $IMAGE_NAME:latest
 
-    - run:
-        name: Archive Docker image
-        command: |
-          docker save -o image.tar $IMAGE_NAME
+      - run:
+          name: Archive Docker image
+          command: |
+            docker save -o image.tar $IMAGE_NAME
 
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ./image.tar
+      - persist_to_workspace:
+          root: .
+          paths:
+          - ./image.tar
+
   publish-latest:
     executor: docker-publisher
     steps:
-    - attach_workspace:
-        at: /tmp/workspace
-    - setup_remote_docker
-    - run:
-        name: Load archived Docker image
-        command: |
-          docker load -i /tmp/workspace/image.tar
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: |
+            docker load -i /tmp/workspace/image.tar
 
-    - run:
-        name: Publish Docker Image to Docker Hub
-        command: |
-          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-          docker push $IMAGE_NAME:latest
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            docker push $IMAGE_NAME:latest
 
   publish-tag:
     executor: docker-publisher
     steps:
-    - attach_workspace:
-        at: /tmp/workspace
-    - setup_remote_docker
-    - run:
-        name: Load archived Docker image
-        command: |
-          docker load -i /tmp/workspace/image.tar
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: |
+            docker load -i /tmp/workspace/image.tar
 
-    - run:
-        name: Publish Docker Image to Docker Hub
-        command: |
-          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
-          docker push $IMAGE_NAME:$CIRCLE_TAG
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
+            docker push $IMAGE_NAME:$CIRCLE_TAG
 
 workflows:
   version: 2
 
   test:
     jobs:
-    - test:
-        filters:
-          branches:
-            ignore: master
+      - test:
+          filters:
+            branches:
+              ignore: master
   build:
     jobs:
-    - build-image:
-        filters:
-          branches:
-            only: master
-    - publish-latest:
-        requires:
-        - build-image
-        filters:
-          branches:
-            only: master
+      - build-image:
+          filters:
+            branches:
+              only: master
+      - publish-latest:
+          requires:
+          - build-image
+          filters:
+            branches:
+              only: master
   build-tags:
     jobs:
-    - build-image:
-        filters:
-          tags:
-            only: /^[0-9]+\.[0-9]+\.[0-9]+/
-          branches:
-            ignore: /.*/
-    - publish-tag:
-        requires:
-        - build-image
-        filters:
-          tags:
-            only: /^[0-9]+\.[0-9]+\.[0-9]+/
-          branches:
-            ignore: /.*/
+      - build-image:
+          filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/
+      - publish-tag:
+          requires:
+          - build-image
+          filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,17 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'activesupport', '~> 5.2'
 gem 'dry-schema'
 gem 'faraday'
-gem 'thor', '~> 0.20'
+gem 'stanford-mods' # for date parsing
+gem 'thor', '~> 0.20' # for CLI
+gem 'timetwister' # for date parsing
 gem 'traject_plus', '~> 1.3'
 
-group :test do
+group :development, :test do
   gem 'byebug'
   gem 'pry-byebug'
+end
+
+group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'rubocop', '~> 0.64.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     byebug (11.0.1)
+    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     deprecation (1.0.0)
@@ -49,6 +50,8 @@ GEM
       dry-equalizer (~> 0.2, >= 0.2.2)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
+    edtf (3.0.5)
+      activesupport (>= 3.0, < 7.0)
     faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     hashie (3.6.0)
@@ -64,6 +67,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    iso-639 (0.2.8)
     jaro_winkler (1.5.3)
     json (2.2.0)
     jsonpath (1.0.4)
@@ -77,10 +81,19 @@ GEM
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
+    mods (2.4.1)
+      edtf
+      iso-639
+      nokogiri (>= 1.6.6)
+      nom-xml (~> 1.0)
     multi_json (1.13.1)
     multipart-post (2.1.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    nom-xml (1.1.0)
+      activesupport (>= 3.2.18)
+      i18n
+      nokogiri
     parallel (1.17.0)
     parser (2.6.4.1)
       ast (~> 2.4.0)
@@ -126,8 +139,13 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (3.6.0)
+    stanford-mods (2.6.1)
+      activesupport
+      mods (~> 2.2)
     thor (0.20.3)
     thread_safe (0.3.6)
+    timetwister (0.2.7)
+      chronic (~> 0.10.2)
     to_regexp (0.2.1)
     traject (3.2.0)
       concurrent-ruby (>= 0.8.0)
@@ -167,7 +185,9 @@ DEPENDENCIES
   rubocop (~> 0.64.0)
   rubocop-rspec (~> 1.21.0)
   simplecov
+  stanford-mods
   thor (~> 0.20)
+  timetwister
   traject_plus (~> 1.3)
 
 BUNDLED WITH

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'timetwister'
+require 'stanford-mods'
+
+# Macros for Traject transformations.
+module Macros
+  # Macros for parsing dates from Strings
+  module DateParsing
+    # get array of year values in range, when string is:
+    # yyyy-yyyy
+    # yyyy - yyyy (can be one or more spaces by hyphen, but not other types of whitespace)
+    # yyyy  (one element in result)
+    #  will not work for negative numbers, or fewer than 4 digit years
+    def range_array_from_positive_4digits_hyphen
+      lambda do |_record, accumulator|
+        range_years = []
+        accumulator.each do |val|
+          range_years << Timetwister.parse(val).first[:index_dates]
+        end
+        range_years.flatten!.uniq!
+        accumulator.replace(range_years)
+      end
+    end
+
+    # Parse strings like 'Sun, 12 Nov 2017 14:08:12 +0000' for a single year
+    def single_year_from_string
+      lambda do |_record, accumulator, _context|
+        accumulator.map! do |val|
+          Stanford::Mods::DateParsing.year_int_from_date_str(val)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'macros/date_parsing'
+require 'traject_plus'
+
+RSpec.describe Macros::DateParsing do
+  subject(:indexer) do
+    Traject::Indexer.new.tap do |indexer|
+      indexer.instance_eval do
+        extend TrajectPlus::Macros
+        extend Macros::DateParsing
+      end
+    end
+  end
+
+  describe 'single_year_from_string' do
+    context 'Sun, 12 Nov 2017 14:08:12 +0000' do
+      it 'gets 2017' do
+        indexer.instance_eval do
+          to_field 'int_array', accumulate { |record, *_| record[:value] }, single_year_from_string
+        end
+
+        expect(indexer.map_record(value: 'Sun, 12 Nov 2017 14:08:12 +0000')).to include 'int_array' => [2017]
+      end
+    end
+  end
+
+  describe 'range_array_from_positive_4digits_hyphen' do
+    it 'parseable values' do
+      indexer.instance_eval do
+        to_field 'int_array', accumulate { |record, *_| record[:value] }, range_array_from_positive_4digits_hyphen
+      end
+
+      expect(indexer.map_record(value: '2019')).to include 'int_array' => [2019]
+      expect(indexer.map_record(value: '2017-2019')).to include 'int_array' => [2017, 2018, 2019]
+      expect(indexer.map_record(value: '2017 - 2019')).to include 'int_array' => [2017, 2018, 2019]
+      expect(indexer.map_record(value: '2017- 2019')).to include 'int_array' => [2017, 2018, 2019]
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

DLME date slider requires a Solr field with an Array of integer years for the whole range possible in a record.  This PR contains low hanging fruit for parsing out integer dates (and ranges) from strings using 2 existing gems, which will enable appropriate values for the date slider Solr field for about 8 collections.

These methods may be modified in the future to accommodate more data, and may not be relying on unmaintained gems after that.

Note that yes, it is possible to test our lambdas (and we should!)

## Was the documentation (README, API, wiki, ...) updated?

n/a