### PR TITLE
Replaces the excluded from syntax so the error is raised

### DIFF
--- a/lib/dlme_json_schema.rb
+++ b/lib/dlme_json_schema.rb
@@ -31,14 +31,14 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional(:cho_date_range_norm).array(:integer) # this is an array of integers to capture the years in a range
   optional(:cho_dc_rights).array(:str?)
   optional(:cho_description).array(:str?)
-  optional(:cho_edm_type) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }
+  optional(:cho_edm_type).array(:str?, excluded_from?: ['NOT FOUND'])
   optional(:cho_extent).array(:str?)
   optional(:cho_format).array(:str?)
   optional(:cho_has_part).array(:str?)
   optional(:cho_has_type).array(:str?)
   optional(:cho_identifier).array(:str?)
   optional(:cho_is_part_of).array(:str?)
-  optional(:cho_language) { array? { each(:str?, excluded_from?: ['NOT FOUND']) } }
+  optional(:cho_language).array(:str?, excluded_from?: ['NOT FOUND'])
   optional(:cho_medium).array(:str?)
   optional(:cho_provenance).array(:str?)
   optional(:cho_publisher).array(:str?)


### PR DESCRIPTION
## Why was this change made?

This is part of the work in #144 - the existing `dry-validation` syntax for `excluded_from?` does not actually raise the expected validation error. 

With this update I now see:

```
[ERROR] Transform produced invalid data.

The errors are: [#<Dry::Schema::Message text="must not be one of: NOT FOUND" path=[:cho_language, 0] predicate=:excluded_from? input="NOT FOUND">]}
```

## Was the documentation (README, API, wiki, ...) updated?

N/A

A follow up PR will be made to improve the testing around this, however, this change is necessary now for the work that @jacobthill is doing.