### PR TITLE
Tweak circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ executors:
     - image: circleci/buildpack-deps:stretch
 jobs:
   test:
-    environment:
-      CC_TEST_REPORTER_ID: 25f90cb6d13d2dabb943971472fab94fe7eeb7595b7b4000296f1959b7ad13c5
     docker:
       - image: circleci/ruby:2.5.3
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ spec/examples.txt
 
 .pry_history
 coverage
+**/.DS_Store


### PR DESCRIPTION
## Why was this change made?

I added the env var in trying to debug why codeclimate wasn't showing test coverage.  I subsequently realized it was because the tests never run on master branch, and code climate only tracks coverage for master branch.

A PR to address the root cause is coming from Aaron separately.

## Was the documentation (README, API, wiki, ...) updated?

n/a