### PR TITLE
Run tests on master to allow for code coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,6 @@ workflows:
   build:
     jobs:
       - build-image:
-          requires:
-          - test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,11 @@ workflows:
   test:
     jobs:
       - test:
-          filters:
-            branches:
-              ignore: master
   build:
     jobs:
       - build-image:
+          requires:
+          - test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,9 @@ jobs:
 
 workflows:
   version: 2
-
   test:
     jobs:
-      - test:
+      - test
   build:
     jobs:
       - build-image:


### PR DESCRIPTION
## Why was this change made?

In order to report coverage on tests, the tests must be run against master.

## Was the documentation (README, API, wiki, ...) updated?

N/A