### PR TITLE
refactor normalize type, closes #144

### DIFF
--- a/lib/macros/normalize_type.rb
+++ b/lib/macros/normalize_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Macros
+  # Macros for normalizing incoming metadata
+  module NormalizeType
+    # Maps extracted type values to a series of tranlation maps
+    # @example
+    #   normalize_language => lambda { ... }
+    # @return [Proc] a proc that traject can call for each record
+    def normalize_type
+      lambda do |_record, accumulator|
+        accumulator.map!(&:downcase)
+        translation_map = %w[not_found types marc-types
+                             french-types turkish-types].map do |spec|
+          Traject::TranslationMap.new(spec)
+        end.reduce(:merge)
+        translation_map.translate_array!(accumulator)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
Refactor the normalize type code that is repeated in almost every config.

## Was the documentation (README, API, wiki, ...) updated?
NA