### PR TITLE
retrieve Arabic country and provider values from metadata_mapping.json

### DIFF
--- a/lib/adjust_cardinality.rb
+++ b/lib/adjust_cardinality.rb
@@ -21,8 +21,9 @@ class AdjustCardinality
   end
 
   def flatten_top_level(attributes)
-    flatten = %w[id agg_data_provider agg_data_provider_country agg_provider agg_provider_country
-                 agg_is_shown_at agg_is_shown_by agg_preview]
+    flatten = %w[id agg_data_provider agg_data_provider_ar agg_data_provider_country
+                 agg_data_provider_country_ar agg_provider agg_provider_ar agg_provider_country
+                 agg_provider_country_ar agg_is_shown_at agg_is_shown_by agg_preview]
     attributes.except(*flatten).tap do |output|
       flatten.each do |field|
         next unless attributes.key?(field)

--- a/lib/dlme_json_schema.rb
+++ b/lib/dlme_json_schema.rb
@@ -56,7 +56,9 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional('__source'.to_sym).filled(:string)
   # Since the IR is a flattened projection of the MAP, 'agg_aggregated_cho' is not used.
   required(:agg_data_provider).filled(:string)
+  required(:agg_data_provider_ar).filled(:string)
   required(:agg_data_provider_country).filled(:string)
+  required(:agg_data_provider_country_ar).filled(:string)
   optional(:agg_dc_rights).array(:str?)
   optional(:agg_edm_rights).array(:str?) # At least one is required
 
@@ -69,7 +71,9 @@ DlmeJsonSchema = Dry::Schema.JSON do
   optional(:agg_preview).schema(EDMWebResourceSchema) # 0 or 1
 
   required(:agg_provider).filled(:string)
+  required(:agg_provider_ar).filled(:string)
   required(:agg_provider_country).filled(:string)
+  required(:agg_provider_country_ar).filled(:string)
   optional(:agg_same_as).array(:str?) # reference
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -11,12 +11,30 @@ module Macros
       from_settings('agg_provider')
     end
 
+    # Returns the Ara lang provider as specified in the ++agg_provider_ar++
+    # field of ++metadata_mapping.json++
+    # @return [Proc] a proc that traject can call for each record
+    # @example
+    #  provider => "أرشيف ملصق فلسطين"
+    def provider_ar
+      from_settings('agg_provider_ar')
+    end
+
     # Returns the data provider as specified in the ++agg_data_provider++ field of ++metadata_mapping.json++
     # @return [Proc] a proc that traject can call for each record
     # @example
     #  data_provider => "SALT Galata"
     def data_provider
       from_settings('agg_data_provider')
+    end
+
+    # Returns the Ara lang data provider as specified in the ++agg_data_provider_ar++
+    # field of ++metadata_mapping.json++
+    # @return [Proc] a proc that traject can call for each record
+    # @example
+    #  data_provider => "مكتبات ستانفورد"
+    def data_provider_ar
+      from_settings('agg_data_provider_ar')
     end
 
     # Returns the provider country as specified in the ++agg_provider_country++ field of ++metadata_mapping.json++
@@ -27,12 +45,30 @@ module Macros
       from_settings('agg_provider_country')
     end
 
-    # Returns data provider country specified in ++agg_data_provider_country++ field of ++metadata_mapping.json++
+    # Returns the Ara lang provider country as specified in the ++agg_provider_country_ar++
+    # field of ++metadata_mapping.json++
+    # @return [Proc] a proc that traject can call for each record
+    # @example
+    #  provider_country => "الولايات المتحدة الامريكيه"
+    def provider_country_ar
+      from_settings('agg_provider_country_ar')
+    end
+
+    # Returns the data provider country specified in ++agg_data_provider_country++ field of ++metadata_mapping.json++
     # @return [Proc] a proc that traject can call for each record
     # @example
     #  data_provider_country => "France"
     def data_provider_country
       from_settings('agg_data_provider_country')
+    end
+
+    # Returns the Ara lang data provider country specified in ++agg_data_provider_country_ar++
+    # field of ++metadata_mapping.json++
+    # @return [Proc] a proc that traject can call for each record
+    # @example
+    #  data_provider_country => "فرنسا"
+    def data_provider_country_ar
+      from_settings('agg_data_provider_country_ar')
     end
 
     # Returns the given identifier prefixed with the ++inst_id++  as specified in ++metadata_mapping.json++


### PR DESCRIPTION
## Why was this change made?
Need to retrieve the newly added Arabic values for country and data provider from metadata_mapping.json. Changes to configs forthcoming.

## Was the documentation (README, API, wiki, ...) updated?
Yes: https://github.com/sul-dlss/dlme/pull/590