### PR TITLE
macro range_array_from_positive_4digits_hyphen deals with no val…

### DIFF
--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -18,7 +18,7 @@ module Macros
         accumulator.each do |val|
           range_years << Timetwister.parse(val).first[:index_dates]
         end
-        range_years.flatten!.uniq!
+        range_years.flatten!.uniq! if range_years.any?
         accumulator.replace(range_years)
       end
     end

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -36,5 +36,13 @@ RSpec.describe Macros::DateParsing do
       expect(indexer.map_record(value: '2017 - 2019')).to include 'int_array' => [2017, 2018, 2019]
       expect(indexer.map_record(value: '2017- 2019')).to include 'int_array' => [2017, 2018, 2019]
     end
+
+    it 'when missing date' do
+      indexer.instance_eval do
+        to_field 'int_array', accumulate { |record, *_| record[:value] }, range_array_from_positive_4digits_hyphen
+      end
+
+      expect(indexer.map_record({})).to eq({})
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Records with no date values using the date_parsing macro `range_array_from_positive_4digits_hyphen`  were giving this error when indexed:

```
    Exception: NoMethodError: undefined method `uniq!' for nil:NilClass
    /opt/traject/lib/macros/date_parsing.rb:21:in `block in range_array_from_positive_4digits_hyphen'

[ERROR] undefined method `uniq!' for nil:NilClass
/opt/traject/lib/macros/date_parsing.rb:21:in `block in range_array_from_positive_4digits_hyphen': undefined method `uniq!' for nil:NilClass (NoMethodError)
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer/step.rb:138:in `block in execute'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer/step.rb:135:in `each'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer/step.rb:135:in `execute'
	from /usr/local/bundle/gems/traject-3.2.0/lib/traject/indexer.rb:464:in `block (2 levels) in map_to_context!'
...
```

This fixes the problem and allows those records to be indexed.

## Was the documentation (README, API, wiki, ...) updated?

n/a