### PR TITLE
use parse_date gem instead of stanford-mods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'dry-validation'
 gem 'faraday'
 gem 'hijri'
-gem 'stanford-mods' # for date parsing
+gem 'parse_date'
 gem 'thor', '~> 0.20' # for CLI
 gem 'timetwister' # for date parsing
 gem 'traject_plus', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,8 +57,6 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.0, >= 1.3.1)
-    edtf (3.0.5)
-      activesupport (>= 3.0, < 7.0)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     hashie (3.6.0)
@@ -75,7 +73,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    iso-639 (0.2.8)
     jaro_winkler (1.5.3)
     json (2.2.0)
     jsonpath (1.0.4)
@@ -89,20 +86,13 @@ GEM
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
-    mods (2.4.1)
-      edtf
-      iso-639
-      nokogiri (>= 1.6.6)
-      nom-xml (~> 1.0)
     multi_json (1.13.1)
     multipart-post (2.1.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    nom-xml (1.1.0)
-      activesupport (>= 3.2.18)
-      i18n
-      nokogiri
     parallel (1.18.0)
+    parse_date (0.1.0)
+      zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
@@ -147,9 +137,6 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (3.6.0)
-    stanford-mods (2.6.1)
-      activesupport
-      mods (~> 2.2)
     thor (0.20.3)
     thread_safe (0.3.6)
     timetwister (0.2.7)
@@ -178,6 +165,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.4.1)
     yell (2.2.0)
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby
@@ -188,13 +176,13 @@ DEPENDENCIES
   dry-validation
   faraday
   hijri
+  parse_date
   pry-byebug
   rspec
   rspec_junit_formatter
   rubocop (~> 0.64.0)
   rubocop-rspec (~> 1.21.0)
   simplecov
-  stanford-mods
   thor (~> 0.20)
   timetwister
   traject_plus (~> 1.3)

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'timetwister'
-require 'stanford-mods'
+require 'parse_date'
 
 # Macros for Traject transformations.
 module Macros
@@ -27,7 +27,7 @@ module Macros
     def single_year_from_string
       lambda do |_record, accumulator, _context|
         accumulator.map! do |val|
-          Stanford::Mods::DateParsing.year_int_from_date_str(val)
+          ParseDate.year_int_from_date_str(val)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

to use the narrowly focused parse_date gem instead of the broader mods processing gem for date parsing.  (Eventually stanford-mods will use parse_date as well).

## Was the documentation (README, API, wiki, ...) updated?

n/a