### PR TITLE
Remove provider-related fields from cardinality adjuster

### DIFF
--- a/lib/adjust_cardinality.rb
+++ b/lib/adjust_cardinality.rb
@@ -21,9 +21,7 @@ class AdjustCardinality
   end
 
   def flatten_top_level(attributes)
-    flatten = %w[id agg_data_provider agg_data_provider_ar agg_data_provider_country
-                 agg_data_provider_country_ar agg_provider agg_provider_ar agg_provider_country
-                 agg_provider_country_ar agg_is_shown_at agg_is_shown_by agg_preview]
+    flatten = %w[id agg_is_shown_at agg_is_shown_by agg_preview]
     attributes.except(*flatten).tap do |output|
       flatten.each do |field|
         next unless attributes.key?(field)

--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -125,13 +125,5 @@ module Macros
     end
     module_function :acceptable_bcp47_codes
     # rubocop:enable Style/AccessModifierDeclarations
-
-    private
-
-    def from_settings(field)
-      lambda { |_record, accumulator, context|
-        accumulator << context.settings.fetch(field)
-      }
-    end
   end
 end


### PR DESCRIPTION
Fixes #255

## Why was this change made?

These fields do not need to be flattened; they are hashes. Flattening them produces an array of arrays, which breaks validation for language-aware fields.

Also:
* Remove dead code: `Macros::DLME` is using the `TrajectPlus` implementation of `from_settings` so the overridden implementation is never used. Remove it to reduce confusion.

## Was the documentation (README, API, wiki, ...) updated?

nope.