### PR TITLE
add missing requirement

### DIFF
--- a/lib/record_counter.rb
+++ b/lib/record_counter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'concurrent'
+require 'singleton'
 
 module Dlme
   # A singleton counter for records.


### PR DESCRIPTION
## Why was this change made?
Address missing requirement from record_counter.rb

## Was the documentation (README, API, wiki, ...) updated?
n/a