### PR TITLE
Rejigger how requires are used

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -6,6 +6,8 @@ require 'date'
 require 'json'
 require 'record_counter'
 require 'thor'
+require 'traject'
+require 'traject_plus'
 require 'transformer'
 
 module Dlme

--- a/lib/dlme_json_resource_writer.rb
+++ b/lib/dlme_json_resource_writer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'traject'
 require 'adjust_cardinality'
 require 'contracts'
 

--- a/lib/macros/content_dm.rb
+++ b/lib/macros/content_dm.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
-
 module Macros
   # Macros for working with CONTENTdm data
   module ContentDm

--- a/lib/macros/dlme_marc.rb
+++ b/lib/macros/dlme_marc.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
-
 # Macros for Traject transformations.
 module Macros
   # Macros that change some of Traject's MARC behaviors for the sake of DLME.

--- a/lib/record_counter.rb
+++ b/lib/record_counter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'concurrent'
+require 'singleton'
 
 module Dlme
   # A singleton counter for records.

--- a/lib/transformer.rb
+++ b/lib/transformer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'traject'
-
 module Dlme
   # Generic Traject transformer
   class Transformer

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'cli'
-
 RSpec.describe Dlme::CLI::Transform do
   subject(:cli) { described_class.new }
 

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'macros/date_parsing'
-require 'traject_plus'
 
 RSpec.describe Macros::DateParsing do
   subject(:indexer) do

--- a/spec/lib/traject/macros/dlme_spec.rb
+++ b/spec/lib/traject/macros/dlme_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'macros/dlme'
-require 'traject_plus'
 
 RSpec.describe Macros::DLME do
   let(:klass) do

--- a/spec/lib/traject/macros/met_spec.rb
+++ b/spec/lib/traject/macros/met_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'macros/met'
-require 'traject_plus'
 
 RSpec.describe Macros::Met do
   let(:klass) do

--- a/spec/lib/traject/macros/post_process_spec.rb
+++ b/spec/lib/traject/macros/post_process_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'macros/post_process'
-require 'traject_plus'
 
 RSpec.describe Macros::PostProcess do
   let(:klass) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ SimpleCov.start do
   add_filter 'spec'
 end
 
-require 'traject'
+require 'cli'
 require 'byebug'
 require 'pry-byebug'
 


### PR DESCRIPTION
## Why was this change made?

This fixes an issue we have missed thus far w/ the `singleton` library not being required anywhere. 

The changes in this branch concentrate most requires for the gem into `lib/cli.rb` since it is the only entrypoint into the gem at this point. We require traject and traject_plus there so we do not need to require it higgledy-piggledy throughout the codebase. We require `singleton` in the `RecordCounter` class since it is only used in that one context. And we require `cli` in the specs so that the test suite uses the libraries *as required in the gem*, which helps surface errors specifying requirements.

## Was the documentation (README, API, wiki, ...) updated?

no