### PR TITLE
upgrade to parse_date 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
-    parse_date (0.1.0)
+    parse_date (0.2.0)
       zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
@@ -170,7 +170,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.4.1)
     yell (2.2.0)
-    zeitwerk (2.1.10)
+    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -51,9 +51,7 @@ module Macros
           accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
         else
           single_date_nodeset = record.xpath(FGDC_SINGLE_DATE_XPATH, FGDC_NS)
-          if single_date_nodeset.present?
-            accumulator.replace([ParseDate.earliest_year(single_date_nodeset.text&.strip)])
-          end
+          accumulator.replace([ParseDate.earliest_year(single_date_nodeset.text&.strip)]) if single_date_nodeset.present?
         end
       end
     end

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -28,7 +28,7 @@ module Macros
     def single_year_from_string
       lambda do |_record, accumulator, _context|
         accumulator.map! do |val|
-          ParseDate.year_int_from_date_str(val)
+          ParseDate.earliest_year(val)
         end
       end
     end
@@ -46,13 +46,13 @@ module Macros
       lambda do |record, accumulator, _context|
         date_range_nodeset = record.xpath(FGDC_DATE_RANGE_XPATH, FGDC_NS)
         if date_range_nodeset.present?
-          first_year = ParseDate.year_int_from_date_str(date_range_nodeset.xpath('begdate', FGDC_NS)&.text&.strip)
-          last_year = ParseDate.year_int_from_date_str(date_range_nodeset.xpath('enddate', FGDC_NS)&.text&.strip)
+          first_year = ParseDate.earliest_year(date_range_nodeset.xpath('begdate', FGDC_NS)&.text&.strip)
+          last_year = ParseDate.earliest_year(date_range_nodeset.xpath('enddate', FGDC_NS)&.text&.strip)
           accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
         else
           single_date_nodeset = record.xpath(FGDC_SINGLE_DATE_XPATH, FGDC_NS)
           if single_date_nodeset.present?
-            accumulator.replace([ParseDate.year_int_from_date_str(single_date_nodeset.text&.strip)])
+            accumulator.replace([ParseDate.earliest_year(single_date_nodeset.text&.strip)])
           end
         end
       end


### PR DESCRIPTION
## Why was this change made?

In preparation for working with distinct "earliest_year" and "latest_year" values for date strings (e.g. for marc date ranges, among others)

## Was the documentation (README, API, wiki, ...) updated?

n/a