### PR TITLE
michigan gets cho_date_range_norm

### DIFF
--- a/traject_configs/michigan_config.rb
+++ b/traject_configs/michigan_config.rb
@@ -2,15 +2,17 @@
 
 require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/date_parsing'
 require 'macros/dlme'
-require 'macros/oai'
 require 'macros/michigan'
+require 'macros/oai'
 require 'macros/post_process'
 
-extend Macros::PostProcess
+extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::Michigan
 extend Macros::OAI
+extend Macros::PostProcess
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml
 
@@ -29,7 +31,9 @@ to_field 'cho_title', extract_xpath("//datafield[@tag='880']/subfield[contains(t
 to_field 'cho_creator', extract_xpath("//datafield[@tag='100']/subfield[@code='a']")
 to_field 'cho_creator', extract_xpath("//datafield[@tag='880']/subfield[contains(text(),'100-01/')]/../subfield[@code='a']"), strip
 to_field 'cho_date', extract_xpath("//datafield[@tag='260']"), strip
-# to_field 'cho_date_range_norm', extract_xpath("//datafield[@tag='260']"), strip
+to_field 'cho_date_range_norm', extract_xpath("//controlfield[@tag='008']"),
+         ->(_rec, acc) { acc.map! { |raw| raw[6..14] } },
+         marc_date_range
 to_field 'cho_description', extract_xpath("//datafield[@tag='300']"), strip
 to_field 'cho_description', extract_xpath("//datafield[@tag='520']"), strip
 to_field 'cho_description', extract_xpath("//datafield[@tag='500']"),


### PR DESCRIPTION
## Why was this change made?

michigan collection gets populated `cho_date_range_norm` field.   

I coded this, rather than leaving it for Jacob, because I thought it might be tricky to get the correct bytes out of the 008 control field when it is parsed as XML.  (See PR #273 for the nifty facility traject provides for marc21 format).

Must have @jacobthill's approval after he has a chance to vet the resulting output.

Note that I ran this against the data, and a bunch of records went through, but it did halt on bad data (date range that was invalid).

## Was the documentation (README, API, wiki, ...) updated?

n/a

closes #263