### PR TITLE
Add array_from_range macro

### DIFF
--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -16,7 +16,7 @@ module Macros
 
         range_years = accumulator.first.delete(' ')
 
-        unless range_years.=~(/^[0-9-;]+$/)
+        unless range_years.match?(/^[0-9-;]+$/)
           accumulator.replace([])
           return
         end

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -8,6 +8,24 @@ module Macros
   # Macros for parsing dates from Strings
   module DateParsing
     # get array of year values in range, when string is:
+    # yyyy; yyyy; yyyy; yyyy; yyyy
+    # works with negative years, but will return an emtpy set of a string is detected
+    def array_from_range
+      lambda do |_record, accumulator|
+        return if accumulator.empty?
+
+        range_years = accumulator.first.delete(' ')
+
+        unless range_years.match(/^[0-9-;]+$/)
+          accumulator.replace([])
+          return
+        end
+
+        accumulator.replace(range_years.split(';').map!(&:to_i))
+      end
+    end
+
+    # get array of year values in range, when string is:
     # yyyy-yyyy
     # yyyy - yyyy (can be one or more spaces by hyphen, but not other types of whitespace)
     # yyyy  (one element in result)

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -16,7 +16,7 @@ module Macros
 
         range_years = accumulator.first.delete(' ')
 
-        unless range_years.match(/^[0-9-;]+$/)
+        unless range_years.=~(/^[0-9-;]+$/)
           accumulator.replace([])
           return
         end

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -12,6 +12,30 @@ RSpec.describe Macros::DateParsing do
     end
   end
 
+  describe '#array_from_range' do
+    before do
+      indexer.instance_eval do
+        to_field 'int_array', accumulate { |record, *_| record[:value] }, array_from_range
+      end
+    end
+
+    it 'gets a range of years' do
+      expect(indexer.map_record(value: '1880; 1881; 1882; 1883; 1884')).to include 'int_array' => [1880, 1881, 1882, 1883, 1884]
+    end
+
+    it 'gets a range of negative years' do
+      expect(indexer.map_record(value: '-881; -880; -879; -878; -877')).to include 'int_array' => [-881, -880, -879, -878, -877]
+    end
+
+    it 'gets a string' do
+      expect(indexer.map_record(value: 'ca. late 19th century')).to be_empty
+    end
+
+    it 'gets a nil value' do
+      expect(indexer.map_record(value: nil)).to be_empty
+    end
+  end
+
   describe '#single_year_from_string' do
     context 'Sun, 12 Nov 2017 14:08:12 +0000' do
       it 'gets 2017' do


### PR DESCRIPTION
## Why was this change made?

This adds a macro that will take the range dates available in AUC (and other collections) as "yyyy; yyyy; yyyy;..." and return an array.

## Was the documentation (README, API, wiki, ...) updated?

N/A