### PR TITLE
Fix missing date_parsing include

### DIFF
--- a/traject_configs/mods_config.rb
+++ b/traject_configs/mods_config.rb
@@ -2,12 +2,14 @@
 
 require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/mods'
 require 'macros/normalize_type'
 require 'macros/stanford'
 require 'macros/post_process'
 
+extend Macros::DateParsing
 extend Macros::PostProcess
 extend Macros::DLME
 extend TrajectPlus::Macros


### PR DESCRIPTION
## Why was this change made?

Without this include, the mods config fails.

## Was the documentation (README, API, wiki, ...) updated?

N/A