### PR TITLE
[DRAFT] AUC gets cho_date_range_name and cho_date_range_hijri

### DIFF
--- a/lib/macros/auc.rb
+++ b/lib/macros/auc.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector' # parameterize method is part of active support
+
+module Macros
+  # Macros for extracting values from CSV rows
+  module Auc
+    # Grab the value from the given column and prefix it with the `inst_id` value
+    # that is set in `config/metadata_mapping.json`
+    # @param header_or_index [String,Integer] the value of the header or index that identifies the column
+    def normalize_prefixed_id(header_or_index)
+      lambda do |row, accumulator, context|
+        identifier = row[header_or_index].to_s.parameterize
+        accumulator << identifier_with_prefix(context, identifier) if identifier.present?
+      end
+    end
+  end
+end

--- a/traject_configs/auc_config.rb
+++ b/traject_configs/auc_config.rb
@@ -33,6 +33,7 @@ to_field 'cho_coverage', extract_oai('dc:coverage'), strip
 to_field 'cho_creator', extract_oai('dc:creator'),
          strip, split('.')
 to_field 'cho_date', extract_oai('dc:date'), strip
+to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, range_array_from_positive_4digits_hyphen
 to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, array_from_range
 to_field 'cho_date_range_hijri', extract_oai('dc:date'), strip, array_from_range, hijri_range
 to_field 'cho_description', extract_oai('dc:description'), strip

--- a/traject_configs/auc_config.rb
+++ b/traject_configs/auc_config.rb
@@ -34,6 +34,7 @@ to_field 'cho_creator', extract_oai('dc:creator'),
          strip, split('.')
 to_field 'cho_date', extract_oai('dc:date'), strip
 to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, array_from_range
+to_field 'cho_date_range_hijri', extract_oai('dc:date'), strip, array_from_range, hijri_range
 to_field 'cho_description', extract_oai('dc:description'), strip
 to_field 'cho_dc_rights', extract_oai('dc:rights'), strip
 to_field 'cho_edm_type', extract_oai('dc:type'),

--- a/traject_configs/auc_config.rb
+++ b/traject_configs/auc_config.rb
@@ -3,11 +3,13 @@
 require 'active_support/core_ext/string/inflections'
 require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/oai'
 require 'macros/content_dm'
 require 'macros/post_process'
 
+extend Macros::DateParsing
 extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::OAI
@@ -31,7 +33,7 @@ to_field 'cho_coverage', extract_oai('dc:coverage'), strip
 to_field 'cho_creator', extract_oai('dc:creator'),
          strip, split('.')
 to_field 'cho_date', extract_oai('dc:date'), strip
-# to_field 'cho_date_range_norm', extract_oai('dc:date'), strip
+to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, array_from_range
 to_field 'cho_description', extract_oai('dc:description'), strip
 to_field 'cho_dc_rights', extract_oai('dc:rights'), strip
 to_field 'cho_edm_type', extract_oai('dc:type'),


### PR DESCRIPTION
## Why was this change made?

Fixes #180 

Requires @jacobthill testing

Takes the provided dc:date values of "yyyy; yyyy; yyyy;...." and normalizes into an array and converts into a hijri array:

```
"cho_date":
["1960; 1961; 1962; 1963; 1964; 1965; 1966; 1967; 1968; 1969; 1970; 1971; 1972; 1973; 1974; 1975; 1976; 1977; 1978; 1979; 1980; 1981; 1982; 1983; 1984; 1985; 1986; 1987; 1988; 1989"],
"cho_date_range_norm":[1960,1961,1962,1963,1964,1965,1966,1967,1968,1969,1970,1971,1972,1973,1974,1975,1976,1977,1978,1979,1980,1981,1982,1983,1984,1985,1986,1987,1988,1989],
"cho_date_range_hijri":[1379,1380,1381,1382,1383,1384,1385,1386,1387,1388,1389,1390,1391,1392,1393,1394,1395,1396,1397,1398,1399,1400,1401,1402,1403,1404,1405,1406,1407,1408,1409,1410]
```

## Was the documentation (README, API, wiki, ...) updated?

N/A