### PR TITLE
add rubocop exception for module length for date_parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,11 @@ Metrics/LineLength:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Exclude:
-  - 'spec/**/*_spec.rb'
+    - 'spec/**/*_spec.rb'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'lib/macros/date_parsing.rb'
 
 Performance/StringReplacement:
   Exclude:


### PR DESCRIPTION
## Why was this change made?

So rubocop will pass in the interim while we figure out our refactoring strategy for DateParsing macros.

## Was the documentation (README, API, wiki, ...) updated?

n/a