### PR TITLE
add Arabic translation map for cho_has_type

### DIFF
--- a/lib/translation_maps/norm_has_type_to_ar.yaml
+++ b/lib/translation_maps/norm_has_type_to_ar.yaml
@@ -1,4 +1,3 @@
-
 Cultural Artifact: قطعة أثرية ثقافية
 Drawing: رسم
 Map: خريطة

--- a/lib/translation_maps/norm_has_type_to_ar.yaml
+++ b/lib/translation_maps/norm_has_type_to_ar.yaml
@@ -1,0 +1,16 @@
+
+Cultural Artifact: قطعة أثرية ثقافية
+Drawing: رسم
+Map: خريطة
+Painting: خرائط
+Photograph: صورة فوتوغرافية
+Poster: ملصق
+Interview: مقابلة
+Music: موسيقي
+Radio Broadcast: البث الإذاعي
+Sound Recording: تسجيل الصوت
+Book: كتاب
+Manuscript: ماذة من مخطوطة
+Newspaper: صحفي
+Periodical: دورية
+Motion Picture: فيلم


### PR DESCRIPTION
## Why was this change made?
Add Arabic translation map for cho_has_type values, closes #155. An additional translation map may be necessary but this won't be clear until the mapping is underway.

## Was the documentation (README, API, wiki, ...) updated?
n/a