### PR TITLE
Add rake tasks for rubocop and rspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,6 @@ jobs:
           - vendor/bundle
 
       - run:
-          name: Check styles using rubocop
-          command: bundle exec rubocop
-
-      - run:
           name: Setup Code Climate test-reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -53,11 +49,11 @@ jobs:
           command: |
             curl -L https://github.com/sul-dlss/dlme-metadata/archive/master.zip > master.zip
             unzip -q master.zip
-            cp -r dlme-metadata-master/[a-z]* data/
+            mv dlme-metadata-master/* data/
 
       - run:
-          name: Run rspec tests
-          command: bundle exec rspec
+          name: Run Rubocop and RSpec tests
+          command: bundle exec rake
 
       - run:
           name: Send coverage report to Code Climate

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note that actual S3 credentials are available from `shared_configs`.
 
 For more information on traject, [read the documentation](https://github.com/traject/traject#Traject)
 
-### Configuring transforms
+## Configuring transforms
 
 Configuration for transforms is specified in `config/metadata_mapping.json`. For example:
 
@@ -131,7 +131,7 @@ Traject indexer as additional settings.
 Additional metadata mappings can be added to this file. In case a metadata file
 matches more than one configuration, the first one wins.
 
-#### Sorting transform configs
+### Sorting transform configs
 
 To enhance readability of the transform configuration (`config/metadata_mapping.json`), a Rake task has been added. The task loads the contents of `config/metadata_mapping.json` into memory, sorts the array alphabetically (ascending, *i.e.*, A-Z) by the first value in the mapping's `paths` array. This way, the mappings for AIMS and AUC will appear before those for Stanford and Princeton and it ought to be easier to locate mappings within the file.
 
@@ -154,4 +154,12 @@ unmapped language is encountered. For example:
 ```ruby
 to_field 'cho_language', extract_xpath("#{record}/dc:language", ns: NS), first_only,
          strip, translation_map('not_found', 'marc_languages')
+```
+
+## Testing
+
+To run the code linter (Rubocop) and the test suite, including unit and integration tests, run:
+
+```shell
+$ bundle exec rake
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,14 @@
 $LOAD_PATH.unshift(File.join(File.expand_path(__dir__), 'lib'))
 
 require 'cli' # loads dependency tree needed for tasks below
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+RSpec::Core::RakeTask.new(:spec)
+
+desc 'Run linter and tests'
+task default: %i[rubocop spec]
 
 desc 'Mapping-related tasks'
 namespace :mappings do


### PR DESCRIPTION
## Why was this change made?

Consistency with other codebases. Less to remember.

Invoke the default rake task in the CI build.

## Was the documentation (README, API, wiki, ...) updated?

Yes.