### PR TITLE
Parse date 0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'faraday'
 gem 'parse_date'
 gem 'rake'
 gem 'thor', '~> 0.20' # for CLI
-gem 'timetwister' # for date parsing
 gem 'traject_plus', '~> 1.3'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
-    parse_date (0.2.0)
+    parse_date (0.3.1)
       zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     byebug (11.0.1)
-    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     config (2.0.0)
@@ -144,8 +143,6 @@ GEM
     slop (3.6.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timetwister (0.2.7)
-      chronic (~> 0.10.2)
     to_regexp (0.2.1)
     traject (3.2.0)
       concurrent-ruby (>= 0.8.0)
@@ -190,7 +187,6 @@ DEPENDENCIES
   rubocop-rspec (~> 1.21.0)
   simplecov
   thor (~> 0.20)
-  timetwister
   traject_plus (~> 1.3)
 
 BUNDLED WITH

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -37,7 +37,9 @@ module Macros
       end
     end
 
-    # Extracts earliest & latest dates from American Numismatic Society record and merges into singe date range value
+    # Extracts earliest & latest dates from American Numismatic Society record and merges into single date range value
+    # parse_range balks because there are values '-2100 - -2000' and it doesn't go that "low" for parse_range method
+    # See https://github.com/sul-dlss/parse_date/issues/31 and https://github.com/sul-dlss/dlme-transform/issues/295
     def american_numismatic_date_range
       lambda do |_record, accumulator|
         return if accumulator.empty?

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'timetwister'
 require 'parse_date'
 
 # Macros for Traject transformations.
@@ -25,16 +24,13 @@ module Macros
       end
     end
 
-    # get array of year values in range, when string is:
-    # yyyy-yyyy
-    # yyyy - yyyy (can be one or more spaces by hyphen, but not other types of whitespace)
-    # yyyy  (one element in result)
-    #  will not work for negative numbers, or fewer than 4 digit years
-    def range_array_from_positive_4digits_hyphen
+    # given a string with date info, use parse_date gem to get an array of indicated years as integers
+    #  See https://github.com/sul-dlss/parse_date for info on what it can parse
+    def parse_range
       lambda do |_record, accumulator|
         range_years = []
         accumulator.each do |val|
-          range_years << Timetwister.parse(val).first[:index_dates]
+          range_years << ParseDate.parse_range(val)
         end
         range_years.flatten!.uniq! if range_years.any?
         accumulator.replace(range_years)

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -46,7 +46,7 @@ module Macros
         dates = val.split('|')
         first_year = dates[0].to_i if dates[0]&.match(/\d+/)
         last_year = dates[1].to_i if dates[1]&.match(/\d+/)
-        accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
+        accumulator.replace(ParseDate.range_array(first_year, last_year))
       end
     end
 
@@ -65,7 +65,7 @@ module Macros
         if date_range_nodeset.present?
           first_year = ParseDate.earliest_year(date_range_nodeset.xpath('begdate', FGDC_NS)&.text&.strip)
           last_year = ParseDate.earliest_year(date_range_nodeset.xpath('enddate', FGDC_NS)&.text&.strip)
-          accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
+          accumulator.replace(ParseDate.range_array(first_year, last_year))
         else
           single_date_nodeset = record.xpath(FGDC_SINGLE_DATE_XPATH, FGDC_NS)
           accumulator.replace([ParseDate.earliest_year(single_date_nodeset.text&.strip)]) if single_date_nodeset.present?
@@ -95,7 +95,7 @@ module Macros
         elsif date_type == 'r'
           first_year = ParseDate.earliest_year(val[5..8])
         end
-        accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
+        accumulator.replace(ParseDate.range_array(first_year, last_year))
       end
     end
 
@@ -104,7 +104,7 @@ module Macros
       lambda do |record, accumulator, _context|
         first_year = record['objectBeginDate']
         last_year = record['objectEndDate']
-        accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
+        accumulator.replace(ParseDate.range_array(first_year, last_year))
       end
     end
 
@@ -124,7 +124,7 @@ module Macros
       lambda do |record, accumulator, _context|
         first_year = record['date_made_early'].to_i if record['date_made_early']&.match(/\d+/)
         last_year = record['date_made_late'].to_i if record['date_made_late']&.match(/\d+/)
-        accumulator.replace(Macros::DateParsing.year_array(first_year, last_year))
+        accumulator.replace(ParseDate.range_array(first_year, last_year))
       end
     end
 
@@ -138,29 +138,6 @@ module Macros
       return unless year.is_a? Integer
 
       (HIJRI_MODIFIER * (year - HIJRI_OFFSET)).floor
-    end
-
-    # @param [String] first_year, expecting parseable string for .to_i
-    # @param [String] last_year year, expecting parseable string for .to_i
-    # @return [Array] array of Integer year values from first to last, inclusive
-    def self.year_array(first_year, last_year)
-      first_year = first_year.to_i if first_year.is_a? String
-      last_year = last_year.to_i if last_year.is_a? String
-
-      return [] unless last_year || first_year
-      return [first_year] if last_year.nil? && first_year
-      return [last_year] if first_year.nil? && last_year
-      raise(StandardError, "unable to create year array from #{first_year}, #{last_year}") unless
-        year_range_valid?(first_year, last_year)
-
-      Range.new(first_year, last_year).to_a
-    end
-
-    def self.year_range_valid?(first_year, last_year)
-      return false if first_year > Date.today.year + 2 || last_year > Date.today.year + 2
-      return false if first_year > last_year
-
-      true
     end
   end
 end

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -37,16 +37,6 @@ module Macros
       end
     end
 
-    # Parse strings like 'Sun, 12 Nov 2017 14:08:12 +0000' for a single year
-    # nil if the year is NOT between -999 and (current year + 2), per parse_date gem
-    def single_year_from_string
-      lambda do |_record, accumulator, _context|
-        accumulator.map! do |val|
-          ParseDate.earliest_year(val)
-        end
-      end
-    end
-
     # Extracts earliest & latest dates from American Numismatic Society record and merges into singe date range value
     def american_numismatic_date_range
       lambda do |_record, accumulator|

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -42,18 +42,6 @@ RSpec.describe Macros::DateParsing do
     end
   end
 
-  describe '#single_year_from_string' do
-    context 'Sun, 12 Nov 2017 14:08:12 +0000' do
-      it 'gets 2017' do
-        indexer.instance_eval do
-          to_field 'int_array', accumulate { |record, *_| record[:value] }, single_year_from_string
-        end
-
-        expect(indexer.map_record(value: 'Sun, 12 Nov 2017 14:08:12 +0000')).to include 'int_array' => [2017]
-      end
-    end
-  end
-
   describe '#parse_range' do
     before do
       indexer.instance_eval do
@@ -75,6 +63,7 @@ RSpec.describe Macros::DateParsing do
       expect(indexer.map_record(value: 'between 300 and 150 B.C')).to include 'int_array' => (-300..-150).to_a
       expect(indexer.map_record(value: '18th century CE')).to include 'int_array' => (1700..1799).to_a
       expect(indexer.map_record(value: 'ca. 10th–9th century B.C.')).to include 'int_array' => (-1099..-900).to_a
+      expect(indexer.map_record(value: 'Sun, 12 Nov 2017 14:08:12 +0000')).to include 'int_array' => [2017] # aims
     end
 
     it 'when missing date' do

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -54,18 +54,27 @@ RSpec.describe Macros::DateParsing do
     end
   end
 
-  describe '#range_array_from_positive_4digits_hyphen' do
+  describe '#parse_range' do
     before do
       indexer.instance_eval do
-        to_field 'int_array', accumulate { |record, *_| record[:value] }, range_array_from_positive_4digits_hyphen
+        to_field 'int_array', accumulate { |record, *_| record[:value] }, parse_range
       end
     end
 
     it 'parseable values' do
       expect(indexer.map_record(value: '2019')).to include 'int_array' => [2019]
+      expect(indexer.map_record(value: '12/25/00')).to include 'int_array' => [2000]
+      expect(indexer.map_record(value: '5-1-25')).to include 'int_array' => [1925]
+      expect(indexer.map_record(value: '-914')).to include 'int_array' => [-914]
+      expect(indexer.map_record(value: '1666 B.C.')).to include 'int_array' => [-1666]
       expect(indexer.map_record(value: '2017-2019')).to include 'int_array' => [2017, 2018, 2019]
-      expect(indexer.map_record(value: '2017 - 2019')).to include 'int_array' => [2017, 2018, 2019]
-      expect(indexer.map_record(value: '2017- 2019')).to include 'int_array' => [2017, 2018, 2019]
+      expect(indexer.map_record(value: 'between 1830 and 1899?')).to include 'int_array' => (1830..1899).to_a
+      expect(indexer.map_record(value: '196u')).to include 'int_array' => (1960..1969).to_a
+      expect(indexer.map_record(value: '17--')).to include 'int_array' => (1700..1799).to_a
+      expect(indexer.map_record(value: '1602 or 1603')).to include 'int_array' => [1602, 1603]
+      expect(indexer.map_record(value: 'between 300 and 150 B.C')).to include 'int_array' => (-300..-150).to_a
+      expect(indexer.map_record(value: '18th century CE')).to include 'int_array' => (1700..1799).to_a
+      expect(indexer.map_record(value: 'ca. 10th–9th century B.C.')).to include 'int_array' => (-1099..-900).to_a
     end
 
     it 'when missing date' do

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -230,7 +230,8 @@ RSpec.describe Macros::DateParsing do
       end
 
       it 'invalid range raises exception' do
-        expect { indexer.map_record('objectBeginDate' => '1539', 'objectEndDate' => '1292') }.to raise_error(StandardError, 'unable to create year array from 1539, 1292')
+        exp_err_msg = 'unable to create year range array from 1539, 1292'
+        expect { indexer.map_record('objectBeginDate' => '1539', 'objectEndDate' => '1292') }.to raise_error(StandardError, exp_err_msg)
       end
     end
 
@@ -268,11 +269,13 @@ RSpec.describe Macros::DateParsing do
       end
 
       it 'invalid range raises exception' do
-        expect { indexer.map_record('date_made_early' => '1539', 'date_made_late' => '1292') }.to raise_error(StandardError, 'unable to create year array from 1539, 1292')
+        exp_err_msg = 'unable to create year range array from 1539, 1292'
+        expect { indexer.map_record('date_made_early' => '1539', 'date_made_late' => '1292') }.to raise_error(StandardError, exp_err_msg)
       end
 
       it 'future date year raises exception' do
-        expect { indexer.map_record('date_made_early' => '1539', 'date_made_late' => '2050') }.to raise_error(StandardError, 'unable to create year array from 1539, 2050')
+        exp_err_msg = 'unable to create year range array from 1539, 2050'
+        expect { indexer.map_record('date_made_early' => '1539', 'date_made_late' => '2050') }.to raise_error(StandardError, exp_err_msg)
       end
     end
 
@@ -291,41 +294,6 @@ RSpec.describe Macros::DateParsing do
 
     it 'date strings with text and numbers are interpreted as 0' do
       expect(indexer.map_record('date_made_early' => 'not999', 'date_made_late' => 'year of 1939')).to include 'range' => [0]
-    end
-  end
-
-  describe '#year_array' do
-    context 'valid input' do
-      [
-        ['1993', '1995', [1993, 1994, 1995]],
-        ['0', '0001', [0, 1]],
-        ['-0003', '0000', [-3, -2, -1, 0]],
-        ['-1', '1', [-1, 0, 1]],
-        ['15', '15', [15]],
-        ['-100', '-99', [-100, -99]],
-        ['98', '101', [98, 99, 100, 101]]
-      ].each do |example|
-        first_year = example[0]
-        last_year = example[1]
-        expected = example[2]
-        it "(#{first_year} to #{last_year})" do
-          expect(Macros::DateParsing.year_array(first_year, last_year)).to eq expected
-        end
-      end
-    end
-    context 'invalid input' do
-      [
-        ['1993', '1992'],
-        ['-99', '-100'],
-        ['12345', '12345']
-      ].each do |example|
-        first_year = example[0]
-        last_year = example[1]
-        it "(#{first_year} to #{last_year})" do
-          exp_msg_regex = /unable to create year array from #{first_year}, #{last_year}/
-          expect { Macros::DateParsing.year_array(first_year, last_year) }.to raise_error(StandardError, exp_msg_regex)
-        end
-      end
     end
   end
 end

--- a/traject_configs/aims_config.rb
+++ b/traject_configs/aims_config.rb
@@ -25,8 +25,8 @@ to_field 'cho_title', extract_aims('title'), strip
 # CHO Other
 to_field 'cho_creator', extract_aims('author'), strip
 to_field 'cho_date', extract_aims('pubDate'), strip
-to_field 'cho_date_range_norm', extract_aims('pubDate'), strip, single_year_from_string
-to_field 'cho_date_range_hijri', extract_aims('pubDate'), strip, single_year_from_string, hijri_range
+to_field 'cho_date_range_norm', extract_aims('pubDate'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_aims('pubDate'), strip, parse_range, hijri_range
 to_field 'cho_dc_rights', literal('Use of content for classroom purposes
                                   and on other non-profit educational websites is granted (and encouraged) with proper citation.')
 to_field 'cho_description', extract_aims('summary'), strip

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -28,8 +28,8 @@ to_field 'cho_contributor', extract_oai('dc:contributor'),
 to_field 'cho_creator', extract_oai('dc:creator'),
          strip, split('.')
 to_field 'cho_date', extract_oai('dc:date'), strip
-to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, range_array_from_positive_4digits_hyphen
-to_field 'cho_date_range_hijri', extract_oai('dc:date'), strip, range_array_from_positive_4digits_hyphen, hijri_range
+to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_oai('dc:date'), strip, parse_range, hijri_range
 to_field 'cho_description', extract_oai('dc:description[2]'), strip
 to_field 'cho_dc_rights', extract_oai('dc:rights'), strip
 to_field 'cho_edm_type', extract_oai('dc:type'),

--- a/traject_configs/bnf_common_config.rb
+++ b/traject_configs/bnf_common_config.rb
@@ -27,8 +27,8 @@ to_field 'cho_provenance', literal('This document is part of BnF website \'Bibli
 
 # Cho Other
 to_field 'cho_date', extract_srw('dc:date'), strip
-to_field 'cho_date_range_norm', extract_srw('dc:date'), strip, range_array_from_positive_4digits_hyphen
-to_field 'cho_date_range_hijri', extract_srw('dc:date'), strip, range_array_from_positive_4digits_hyphen, hijri_range
+to_field 'cho_date_range_norm', extract_srw('dc:date'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_srw('dc:date'), strip, parse_range, hijri_range
 to_field 'cho_description', extract_srw('dc:description'), strip
 to_field 'cho_dc_rights', extract_srw('dc:rights'), strip
 to_field 'cho_format', extract_srw('dc:format'), strip

--- a/traject_configs/cluster_config.rb
+++ b/traject_configs/cluster_config.rb
@@ -25,8 +25,8 @@ to_field 'cho_title', extract_json('.title'), strip
 to_field 'cho_creator', extract_json('.creator'), strip
 to_field 'cho_contributor', extract_json('.contributor'), strip
 to_field 'cho_date', extract_json('.date'), strip
-to_field 'cho_date_range_norm', extract_json('.date'), strip, range_array_from_positive_4digits_hyphen
-to_field 'cho_date_range_hijri', extract_json('.date'), strip, range_array_from_positive_4digits_hyphen, hijri_range
+to_field 'cho_date_range_norm', extract_json('.date'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date'), strip, parse_range, hijri_range
 to_field 'cho_description', extract_json('.description'), strip
 to_field 'cho_edm_type', literal('Dataset')
 to_field 'cho_language', literal('English')

--- a/traject_configs/pppa_config.rb
+++ b/traject_configs/pppa_config.rb
@@ -26,7 +26,8 @@ to_field 'cho_title', column('Title')
 # CHO Other
 to_field 'cho_creator', column('Creator')
 to_field 'cho_date', column('Date')
-# to_field 'cho_date_range_norm', column('Date'), range_array_from_positive_4digits_hyphen
+to_field 'cho_date_range_norm', column('Date'), parse_range
+to_field 'cho_date_range_hijri', column('Date'), parse_range, hijri_range
 to_field 'cho_description', column('Description')
 to_field 'cho_edm_type', literal('Image')
 to_field 'cho_identifier', column('Resource-URL')

--- a/traject_configs/princeton_movie_config.rb
+++ b/traject_configs/princeton_movie_config.rb
@@ -25,8 +25,8 @@ to_field 'cho_title', extract_json('.title'), strip
 to_field 'cho_contributor', extract_json('.director'), strip
 to_field 'cho_contributor', extract_json('.rendered_actors'), strip
 to_field 'cho_date', extract_json('.date_created'), strip
-to_field 'cho_date_range_norm', extract_json('.date_created'), strip, range_array_from_positive_4digits_hyphen
-to_field 'cho_date_range_hijri', extract_json('.date_created'), strip, range_array_from_positive_4digits_hyphen, hijri_range
+to_field 'cho_date_range_norm', extract_json('.date_created'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date_created'), strip, parse_range, hijri_range
 to_field 'cho_dc_rights', literal('https://rbsc.princeton.edu/services/imaging-publication-services')
 to_field 'cho_description', extract_json('.member_of_collections'), strip
 to_field 'cho_edm_type', literal('Image')

--- a/traject_configs/princeton_mss_config.rb
+++ b/traject_configs/princeton_mss_config.rb
@@ -26,8 +26,8 @@ to_field 'cho_alternate', extract_json('.cho_alternate'), strip
 to_field 'cho_creator', extract_json('.author'), strip
 to_field 'cho_contributor', extract_json('.contributor'), strip
 to_field 'cho_date', extract_json('.date'), strip
-to_field 'cho_date_range_norm', extract_json('.date'), strip, range_array_from_positive_4digits_hyphen
-to_field 'cho_date_range_hijri', extract_json('.date'), strip, range_array_from_positive_4digits_hyphen, hijri_range
+to_field 'cho_date_range_norm', extract_json('.date'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date'), strip, parse_range, hijri_range
 to_field 'cho_dc_rights', literal('https://rbsc.princeton.edu/services/imaging-publication-services')
 to_field 'cho_description', extract_json('.description'), strip
 to_field 'cho_description', extract_json('.contents'), strip

--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -26,10 +26,9 @@ to_field 'cho_title', extract_qnl('mods:titleInfo/mods:title')
 to_field 'cho_coverage', extract_qnl('mods:subject/mods:geographic'), strip
 to_field 'cho_creator', extract_qnl('mods:name/mods:namePart'), strip
 to_field 'cho_date', extract_qnl('mods:originInfo/mods:dateIssued'), strip
-to_field 'cho_date_range_norm', extract_qnl('mods:originInfo/mods:dateIssued'),
-         strip, gsub('/', '-'), range_array_from_positive_4digits_hyphen
+to_field 'cho_date_range_norm', extract_qnl('mods:originInfo/mods:dateIssued'), strip, gsub('/', '-'), parse_range
 to_field 'cho_date_range_hijri', extract_qnl('mods:originInfo/mods:dateIssued'),
-         strip, gsub('/', '-'), range_array_from_positive_4digits_hyphen, hijri_range
+         strip, gsub('/', '-'), parse_range, hijri_range
 to_field 'cho_dc_rights', literal('Open Government Licence')
 to_field 'cho_description', extract_qnl('mods:physicalDescription/mods:extent'), strip
 to_field 'cho_edm_type', extract_qnl('mods:typeOfResource'),


### PR DESCRIPTION
## Why was this change made?

Closes #291

This PR shifts more of the date parsing burden to the parse_date gem.  With v0.3.1, a lot more date parsing functionality has been added to the parse_date gem since v0.2.0 (see https://github.com/sul-dlss/parse_date/releases and gem's README), much of it with DLME date string patterns in mind.

The parse_date gem gives us a range of years for anything timetwister could formerly do, plus a lot more patterns, such as BC years and centuries.

The commit messages explain what happened to the date_parsing macro code here.

## Was the documentation (README, API, wiki, ...) updated?

In addition to the comment in DateParsing.parse_range macro referring to the parse_date gem git repo for more info, the spec for DateParsing.parse_range got a lot more examples as a means of some documentation.

This isn't really user facing enough to go in the README or anything like that.