### PR TITLE
add missing date range fields we can currently process to traject configs

### DIFF
--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -45,6 +45,7 @@ to_field 'cho_creator', extract_role('710', 'creator')
 to_field 'cho_creator', extract_role('711', 'creator')
 to_field 'cho_date', marc_publication_date, transform(&:to_s)
 to_field 'cho_date_range_norm', extract_marc('008[06-14]'), marc_date_range
+to_field 'cho_date_range_hijri', extract_marc('008[06-14]'), marc_date_range, hijri_range
 # to_field 'cho_dc_rights', ?
 to_field 'cho_description', extract_marc('500:505:520')
 to_field 'cho_edm_type', marc_type_to_edm

--- a/traject_configs/met_config.rb
+++ b/traject_configs/met_config.rb
@@ -57,6 +57,7 @@ to_field 'cho_medium', extract_json('.medium')
 to_field 'cho_date', generate_object_date, transform(&:presence)
 to_field 'cho_date', extract_json('.objectDate'), transform(&:presence)
 to_field 'cho_date_range_norm', met_date_range
+to_field 'cho_date_range_hijri', met_date_range, hijri_range
 to_field 'cho_identifier', extract_json('.accessionNumber')
 to_field 'cho_source', extract_json('.accessionNumber')
 to_field 'cho_temporal', extract_json('.period'), transform(&:presence)

--- a/traject_configs/michigan_config.rb
+++ b/traject_configs/michigan_config.rb
@@ -34,6 +34,10 @@ to_field 'cho_date', extract_xpath("//datafield[@tag='260']"), strip
 to_field 'cho_date_range_norm', extract_xpath("//controlfield[@tag='008']"),
          ->(_rec, acc) { acc.map! { |raw| raw[6..14] } },
          marc_date_range
+to_field 'cho_date_range_hijri', extract_xpath("//controlfield[@tag='008']"),
+         ->(_rec, acc) { acc.map! { |raw| raw[6..14] } },
+         marc_date_range,
+         hijri_range
 to_field 'cho_description', extract_xpath("//datafield[@tag='300']"), strip
 to_field 'cho_description', extract_xpath("//datafield[@tag='520']"), strip
 to_field 'cho_description', extract_xpath("//datafield[@tag='500']"),

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -36,6 +36,7 @@ to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
 to_field 'cho_date', column('Era')
 to_field 'cho_date', column('Year'), gsub('|', ' - ')
 to_field 'cho_date_range_norm', column('Year'), american_numismatic_date_range
+to_field 'cho_date_range_hijri', column('Year'), american_numismatic_date_range, hijri_range
 to_field 'cho_description', column('Denomination')
 to_field 'cho_description', column('Manufacture')
 to_field 'cho_description', column('Obverse Legend')

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -34,7 +34,8 @@ to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
 to_field 'cho_date', column('date_made')
 to_field 'cho_date', column('date_made_early')
 to_field 'cho_date', column('date_made_late')
-# to_field 'cho_date_range_norm', penn_museum_date_range
+to_field 'cho_date_range_norm', penn_museum_date_range
+to_field 'cho_date_range_hijri', penn_museum_date_range, hijri_range
 to_field 'cho_description', column('description')
 to_field 'cho_description', column('technique'), split('|')
 to_field 'cho_edm_type', literal('Image')


### PR DESCRIPTION
## Why was this change made?

This doc shows the status of current DLME collections for date range normalization

https://docs.google.com/spreadsheets/d/1U068CQlySkxiS2O5W70Uc4uc6t1DrqJGMcUO71CLokY/edit#gid=0

the following collections are supposedly "done" but were missing the config lines.

not sure why some of these lost their `cho_date_range_norm` stuff.  (perhaps a rebase conflict in some later PR, but it doesn't matter.  And `cho_date_range_norm` being missing probably impacted `cho_date_range_hijri` not being added, but again it doesn't matter.)

## Was the documentation (README, API, wiki, ...) updated?

n/a
