### PR TITLE
upgrade parse_date to v0.3.2 and use parse_date macro for numismatic collection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
-    parse_date (0.3.1)
+    parse_date (0.3.2)
       zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -77,21 +77,6 @@ module Macros
       end
     end
 
-    # Extracts earliest & latest dates from American Numismatic Society record and merges into single date range value
-    # parse_range balks because there are values '-2100 - -2000' and it doesn't go that "low" for parse_range method
-    # See https://github.com/sul-dlss/parse_date/issues/31 and https://github.com/sul-dlss/dlme-transform/issues/295
-    def american_numismatic_date_range
-      lambda do |_record, accumulator|
-        return if accumulator.empty?
-
-        val = accumulator.first
-        dates = val.split('|')
-        first_year = dates[0].to_i if dates[0]&.match(/\d+/)
-        last_year = dates[1].to_i if dates[1]&.match(/\d+/)
-        accumulator.replace(ParseDate.range_array(first_year, last_year))
-      end
-    end
-
     FGDC_NS = { fgdc: 'http://www.fgdc.gov/metadata/fgdc-std-001-1998.dtd' }.freeze
     FGDC_TIMEINFO_XPATH = '/metadata/idinfo/timeperd/timeinfo'
     FGDC_SINGLE_DATE_XPATH = "#{FGDC_TIMEINFO_XPATH}/sngdate/caldate"

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -161,18 +161,6 @@ RSpec.describe Macros::DateParsing do
     end
   end
 
-  describe '#american_numismatic_date_range' do
-    it 'both dates and range are valid' do
-      indexer.to_field('range', raw_val_lambda, indexer.american_numismatic_date_range)
-      expect(indexer.map_record(raw: '999|1001')).to include 'range' => [999, 1000, 1001]
-      expect(indexer.map_record(raw: '-1001|-999')).to include 'range' => [-1001, -1000, -999]
-      expect(indexer.map_record(raw: '999')).to include 'range' => [999]
-      expect(indexer.map_record(raw: '999| 1001')).to include 'range' => [999, 1000, 1001]
-      expect(indexer.map_record(raw: '999 |1001')).to include 'range' => [999, 1000, 1001]
-      expect(indexer.map_record(raw: '-99|1')).to include 'range' => (-99..1).to_a
-    end
-  end
-
   describe '#fgdc_date_range' do
     before do
       indexer.instance_eval do

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -35,8 +35,8 @@ to_field 'agg_data_provider', data_provider, lang('en')
 to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
 to_field 'cho_date', column('Era')
 to_field 'cho_date', column('Year'), gsub('|', ' - ')
-to_field 'cho_date_range_norm', column('Year'), american_numismatic_date_range
-to_field 'cho_date_range_hijri', column('Year'), american_numismatic_date_range, hijri_range
+to_field 'cho_date_range_norm', column('Year'), gsub('|', ' - '), parse_range
+to_field 'cho_date_range_hijri', column('Year'), gsub('|', ' - '), parse_range, hijri_range
 to_field 'cho_description', column('Denomination')
 to_field 'cho_description', column('Manufacture')
 to_field 'cho_description', column('Obverse Legend')


### PR DESCRIPTION
## Why was this change made?

Closes # 295.

With the fix for early dates in parse_date gem v0.3.2, there is no need to have a separate macro to parse date ranges for american numismatic society collection.

I ran the ANS collection with the fix and the data looked good, and no exceptions.

## Was the documentation (README, API, wiki, ...) updated?

n/a
