### PR TITLE
update parse_date to v0.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
-    parse_date (0.3.3)
+    parse_date (0.3.4)
       zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)


### PR DESCRIPTION
## Why was this change made?

parse_date gem v0.3.4 handles 3 more parsing cases:

- yyy-yy  used by AU Cairo (e.g. `950-60`)
- yyy-yyyy used by Cambridge (e.g. `996–1021 CE`)
- yyyy to yyyy used by OPenn Free Library Philadelphia (e.g. `1500? to 1582`)

thus we will have better date range data for these cases. 

## Was the documentation (README, API, wiki, ...) updated?

n/a