### PR TITLE
Fix multilingual bug

### DIFF
--- a/lib/contracts/cho.rb
+++ b/lib/contracts/cho.rb
@@ -67,14 +67,19 @@ module Contracts
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def self.required_language_specific_rule
       proc do
         key.failure('no values provided') if value.keys.empty?
         unexpected_keys = value.keys - expected_language_values
         key.failure("unexpected language code(s) found in #{key.path.keys.first}: #{unexpected_keys.join(', ')}") if
           unexpected_keys.any?
+        unexpected_values = value.values&.first&.reject { |value| value.is_a?(String) }
+        key.failure("unexpected non-string value(s) found in #{key.path.keys.first}: #{unexpected_values}") if
+          unexpected_values&.any?
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     rule(:cho_title, &required_language_specific_rule)
     rule(:agg_data_provider, &required_language_specific_rule)

--- a/spec/lib/contracts/cho_spec.rb
+++ b/spec/lib/contracts/cho_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe Contracts::CHO do
           end
         end
 
+        context 'when hash contains unexpected values' do
+          let(:cho) { { field_name => { 'none' => ['none', ['The Real Value']] } } }
+
+          it 'states the field had unexpected keys' do
+            expect(contract.errors[field_name]).to include(
+              "unexpected non-string value(s) found in #{field_name}: [[\"The Real Value\"]]"
+            )
+          end
+        end
+
         context 'when hash looks as expected' do
           let(:cho) do
             {

--- a/traject_configs/stanford_mods_config.rb
+++ b/traject_configs/stanford_mods_config.rb
@@ -77,4 +77,4 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-each_record convert_to_language_hash('agg_data_provider_country', 'agg_provider_country', 'cho_title')
+each_record convert_to_language_hash('agg_data_provider_country', 'agg_provider_country')


### PR DESCRIPTION
## Why was this change made?

Fixes sul-dlss/dlme#603

This bug was caused by having a Traject config (`stanford_mods_config.rb`) attempt to convert a field (`cho_title`) to the language hash which was already converted to the language hash in an earlier config (`mods_config.rb`). I added a validation that will fail the transformation if we do this again (a bug I introduced :D)

## Was the documentation (README, API, wiki, ...) updated?

No.