### PR TITLE
Check whether *any* exception is raised in integration spec

### DIFF
--- a/spec/integration/traject_configs_spec.rb
+++ b/spec/integration/traject_configs_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'integration with Traject configs' do
           config_filepaths: config['trajects'].map { |traject| "#{Settings.defaults.traject_dir}/#{traject}" },
           settings: config.fetch('settings', {})
         ).transform
+      rescue StandardError => e
+        raise "error raised mapping #{config['settings']['inst_id']}: #{e.class}: #{e.message}"
       end
     end.not_to raise_error
   end

--- a/spec/integration/traject_configs_spec.rb
+++ b/spec/integration/traject_configs_spec.rb
@@ -19,6 +19,6 @@ RSpec.describe 'integration with Traject configs' do
           settings: config.fetch('settings', {})
         ).transform
       end
-    end.not_to raise_error(RuntimeError)
+    end.not_to raise_error
   end
 end


### PR DESCRIPTION
## Why was this change made?

Only checking for `RuntimeError` allows for false positives, where we may be missing exceptions. 

This is currently failing because of a data error, and indeed, there could be several dozen or hundred more such errors. As we fix data that does not cleanly map, we should revisit this PR until we get a clean build. 

## Was the documentation (README, API, wiki, ...) updated?

no.