### PR TITLE
penn/openn/philadelphia-museum-art-0031 gets date ranges

### DIFF
--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -409,7 +409,8 @@
   },
   {
     "trajects": [
-      "openn_common_config.rb"
+      "openn_common_config.rb",
+      "openn_orig_date_attribs.rb"
     ],
     "paths": [
       "penn/openn/philadelphia-museum-art-0031"

--- a/traject_configs/openn_orig_date_attribs.rb
+++ b/traject_configs/openn_orig_date_attribs.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Cambridge collections have TEI <origDate notBefore="yyyy" notAfter="yyyy"> so we can leverage it here
+to_field 'cho_date_range_norm', cambridge_gregorian_range
+to_field 'cho_date_range_hijri', cambridge_gregorian_range, hijri_range


### PR DESCRIPTION
## Why was this change made?

Closes #244

OPenn collection philadelphia-museum-art-0031 has a single TEI record.  This record has a date field thus:

```xml
<origDate notBefore="1400" notAfter="1599"/>
```

The Cambridge collections use `notBefore` and `notAfter` attributes, so this PR leverages the cambridge date range macro to get a date range for this OPenn collection.

The result:  

```json
"cho_date_range_norm":[1400,1401,1402,1403,1404,1405,1406,1407,1408,1409,1410,1411,1412,1413,1414,1415,1416,1417,1418,1419,1420,1421,1422,1423,1424,1425,1426,1427,1428,1429,1430,1431,1432,1433,1434,1435,1436,1437,1438,1439,1440,1441,1442,1443,1444,1445,1446,1447,1448,1449,1450,1451,1452,1453,1454,1455,1456,1457,1458,1459,1460,1461,1462,1463,1464,1465,1466,1467,1468,1469,1470,1471,1472,1473,1474,1475,1476,1477,1478,1479,1480,1481,1482,1483,1484,1485,1486,1487,1488,1489,1490,1491,1492,1493,1494,1495,1496,1497,1498,1499,1500,1501,1502,1503,1504,1505,1506,1507,1508,1509,1510,1511,1512,1513,1514,1515,1516,1517,1518,1519,1520,1521,1522,1523,1524,1525,1526,1527,1528,1529,1530,1531,1532,1533,1534,1535,1536,1537,1538,1539,1540,1541,1542,1543,1544,1545,1546,1547,1548,1549,1550,1551,1552,1553,1554,1555,1556,1557,1558,1559,1560,1561,1562,1563,1564,1565,1566,1567,1568,1569,1570,1571,1572,1573,1574,1575,1576,1577,1578,1579,1580,1581,1582,1583,1584,1585,1586,1587,1588,1589,1590,1591,1592,1593,1594,1595,1596,1597,1598,1599],
"cho_date_range_hijri":[802,803,804,805,806,807,808,809,810,811,812,813,814,815,816,817,818,819,820,821,822,823,824,825,826,827,828,829,830,831,832,833,834,835,836,837,838,839,840,841,842,843,844,845,846,847,848,849,850,851,852,853,854,855,856,857,858,859,860,861,862,863,864,865,866,867,868,869,870,871,872,873,874,875,876,877,878,879,880,881,882,883,884,885,886,887,888,889,890,891,892,893,894,895,896,897,898,899,900,901,902,903,904,905,906,907,908,909,910,911,912,913,914,915,916,917,918,919,920,921,922,923,924,925,926,927,928,929,930,931,932,933,934,935,936,937,938,939,940,941,942,943,944,945,946,947,948,949,950,951,952,953,954,955,956,957,958,959,960,961,962,963,964,965,966,967,968,969,970,971,972,973,974,975,976,977,978,979,980,981,982,983,984,985,986,987,988,989,990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008]
```

## Was the documentation (README, API, wiki, ...) updated?

n/a