### PR TITLE
Remove config from docker ignore as it is now required

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 /output/*
 /data/*
-/config/*


### PR DESCRIPTION
## Why was this change made?
We were previously pulling configs from dlme-traject, we know need the base configs from this repository and with them ignored (and thus not built into the container) an error is thrown during the run:

```
[ERROR] No such file or directory @ rb_sysopen - /opt/traject/config/metadata_mapping.json
/opt/traject/lib/config_finder.rb:67:in `read': No such file or directory @ rb_sysopen - /opt/traject/config/metadata_mapping.json (Errno::ENOENT)
```
Note: this is blocking transforms from running in docker and AWS, but not if running manually.

## Was the documentation (README, API, wiki, ...) updated?

N/A
