### PR TITLE
bodleian colls get date ranges

### DIFF
--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -26,7 +26,8 @@ to_field 'cho_title', extract_json('.title'), strip, default('Untitled Item')
 to_field 'cho_creator', extract_json('.author'), strip
 to_field 'cho_contributor', extract_json('.printer'), strip, append(' [printer]')
 to_field 'cho_date', extract_json('.date_statement'), strip
-# to_field 'cho_date_range_norm', extract_json('.date_statement'), strip
+to_field 'cho_date_range_norm', extract_json('.date_statement'), strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date_statement'), strip, parse_range, hijri_range
 to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html')
 to_field 'cho_description', extract_json('.description'), strip
 to_field 'cho_edm_type', literal('Text')


### PR DESCRIPTION
## Why was this change made?

closes #246 

Bodleian collections get date range fields populated

### Notes

I looked at *all* the raw data for Bodleian, and there were only these 4 `date_statement` values that aren't converting to the intuitive correct values:

```
Arabic-12.json:  16th century, first half  # will get whole century (1500..1599)
Armenian-60.json:  1706/7  # will get 1706 only
Armenian-79.json:  1674/5  # will get 1674 only
Hebrew-790.json: Early 16th century # will get whole century (1500..1599) 
```

## Was the documentation (README, API, wiki, ...) updated?

n/a