### PR TITLE
bodleian config gets date parsing macros

### DIFF
--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -2,9 +2,11 @@
 
 require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/post_process'
 
+extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::PostProcess
 extend TrajectPlus::Macros


### PR DESCRIPTION
## Why was this change made?

b/c i did a d'oh.  Bodleian needs access to the date macro code.

## Was the documentation (README, API, wiki, ...) updated?

n/a