### PR TITLE
use parse_date v0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
-    parse_date (0.3.4)
+    parse_date (0.4.0)
       zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
@@ -167,7 +167,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.4.1)
     yell (2.2.0)
-    zeitwerk (2.2.0)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Why was this change made?

Sakip needs the parse_date gem to fail quietly on non-parseable date values.  parse_date gem v0.4.0 provides this.

## Was the documentation (README, API, wiki, ...) updated?

n/a