### PR TITLE
remove unused array_from_range date parsing macro

### DIFF
--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -6,24 +6,6 @@ require 'parse_date'
 module Macros
   # Macros for parsing dates from Strings
   module DateParsing
-    # get array of year values in range, when string is:
-    # yyyy; yyyy; yyyy; yyyy; yyyy
-    # works with negative years, but will return an emtpy set of a string is detected
-    def array_from_range
-      lambda do |_record, accumulator|
-        return if accumulator.empty?
-
-        range_years = accumulator.first.delete(' ')
-
-        unless range_years.match?(/^[0-9\-;]+$/)
-          accumulator.replace([])
-          return
-        end
-
-        accumulator.replace(range_years.split(';').map!(&:to_i))
-      end
-    end
-
     # given an accumulator containing a string with date info,
     #   use parse_date gem to get an array of indicated years as integers
     #   See https://github.com/sul-dlss/parse_date for info on what it can parse

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -18,30 +18,6 @@ RSpec.describe Macros::DateParsing do
     end
   end
 
-  describe '#array_from_range' do
-    before do
-      indexer.instance_eval do
-        to_field 'int_array', accumulate { |record, *_| record[:value] }, array_from_range
-      end
-    end
-
-    it 'gets a range of years' do
-      expect(indexer.map_record(value: '1880; 1881; 1882; 1883; 1884')).to include 'int_array' => [1880, 1881, 1882, 1883, 1884]
-    end
-
-    it 'gets a range of negative years' do
-      expect(indexer.map_record(value: '-881; -880; -879; -878; -877')).to include 'int_array' => [-881, -880, -879, -878, -877]
-    end
-
-    it 'gets a string' do
-      expect(indexer.map_record(value: 'ca. late 19th century')).to be_empty
-    end
-
-    it 'gets a nil value' do
-      expect(indexer.map_record(value: nil)).to be_empty
-    end
-  end
-
   describe '#parse_range' do
     before do
       indexer.instance_eval do


### PR DESCRIPTION
## Why was this change made?

`array_from_range` was a date parsing macro originally written for UAC collection.  UAC no longer uses it, and neither does anything else.  Closes #293, tho obliquely.

## Was the documentation (README, API, wiki, ...) updated?

n/a