### PR TITLE
Reorg date parsing file slightly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,12 @@ AllCops:
   Exclude:
     - data/**/*
 
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
+Layout/EmptyLinesAroundModuleBody:
+  Exclude:
+    - 'lib/macros/date_parsing.rb' # long file;  some additional spaces and comments to keep it organized
+
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -101,6 +101,7 @@ module Macros
     AUC_REGEX = Regexp.new('\d{4};') # captures the `YYYY; YYYY; YYYY; YYYY;` pattern
     AUC_DELIM = ';'
 
+    # extracts dates from American University of Cairo data
     def auc_date_range
       lambda do |_record, accumulator, _context|
         range_years = []

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -9,18 +9,6 @@ module Macros
 
     # ---------- General macros follow, alphabetical except for additional helper methods
 
-    HIJRI_MODIFIER = 1.030684
-    HIJRI_OFFSET = 621.5643
-
-    # @param [Integer] a single year to be converted
-    # @return [Integer] a converted integer year
-    # This method uses the first formula provided here: https://en.wikipedia.org/wiki/Hijri_year#Formula
-    def self.to_hijri(year)
-      return unless year.is_a? Integer
-
-      (HIJRI_MODIFIER * (year - HIJRI_OFFSET)).floor
-    end
-
     # given an accumulator containing a string with both hijri and gregorian date info,
     #   change the string to only contain gregorian date info
     def extract_gregorian
@@ -48,9 +36,7 @@ module Macros
             hijri_range << ParseDate.parse_range(hijri_val)
           else
             gregorian_range = ParseDate.parse_range(val)
-            hijri_range << (
-              Macros::DateParsing.to_hijri(gregorian_range.first)..Macros::DateParsing.to_hijri(gregorian_range.last) + 1
-            ).to_a
+            hijri_range << (to_hijri(gregorian_range.first)..to_hijri(gregorian_range.last) + 1).to_a
           end
         end
         hijri_range.flatten!.uniq! if hijri_range.any?
@@ -64,9 +50,21 @@ module Macros
       lambda do |_record, accumulator, _context|
         return if accumulator.empty?
 
-        accumulator.replace((
-          Macros::DateParsing.to_hijri(accumulator.first)..Macros::DateParsing.to_hijri(accumulator.last) + 1).to_a)
+        accumulator.replace((to_hijri(accumulator.first)..to_hijri(accumulator.last) + 1).to_a)
       end
+    end
+
+    HIJRI_MODIFIER = 1.030684
+    HIJRI_OFFSET = 621.5643
+
+    # NOTE: this is not a macro, but a helper method for macros
+    # @param [Integer] a single year to be converted
+    # @return [Integer] a converted integer year
+    # This method uses the first formula provided here: https://en.wikipedia.org/wiki/Hijri_year#Formula
+    def to_hijri(year)
+      return unless year.is_a? Integer
+
+      (HIJRI_MODIFIER * (year - HIJRI_OFFSET)).floor
     end
 
     REGEX_OPTS = Regexp::IGNORECASE | Regexp::MULTILINE
@@ -98,7 +96,7 @@ module Macros
       end
     end
 
-    # ---------- Collection specific macros below, alphabetical except for additional helper methods
+    # ---------- Collection or Metadata format specific macros below, alphabetical except for additional helper methods
 
     AUC_REGEX = Regexp.new('\d{4};') # captures the `YYYY; YYYY; YYYY; YYYY;` pattern
     AUC_DELIM = ';'

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Macros::DateParsing do
     end
     context 'when no hijri provided' do
       it 'hijri range is computed from gregorian range' do
-        expect(Macros::DateParsing).to receive(:to_hijri).exactly(4).times.and_call_original
+        expect(indexer).to receive(:to_hijri).exactly(4).times.and_call_original
         expect(indexer.map_record(value: '1894')).to include 'hijri_range' => [1311, 1312]
         expect(indexer.map_record(value: '1886-1887')).to include 'hijri_range' => [1303, 1304, 1305]
       end


### PR DESCRIPTION
## Why was this change made?

The date parsing macros file is on the long side;   
- I organized it into two sections, with comments:  
    - first section is for general purpose macros, organized alphabetically.
    - second section is for collection or metadata format specific macros, arranged alphabetically
- I changed `to_hijri` to be a helper method, not a class method, to be like all the other helper methods.
- I added a comment to the new `auc` macro

### Note:

I made sure the number of specs (all passing) was the same for both master and this branch.  :-)


## Was the documentation (README, API, wiki, ...) updated?

yes, if you count the comments added in the date_parsing file?  Otherwise n/a
