### PR TITLE
Auc errors

### DIFF
--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -98,8 +98,8 @@ module Macros
 
     # ---------- Collection or Metadata format specific macros below, alphabetical except for additional helper methods
 
-    AUC_REGEX = Regexp.new('\d{4};') # captures the `YYYY; YYYY; YYYY; YYYY;` pattern
     AUC_DELIM = ';'
+    AUC_REGEX = Regexp.new("\\d{4}#{AUC_DELIM}") # captures the `YYYY; YYYY; YYYY; YYYY;` pattern
 
     # extracts dates from American University of Cairo data
     def auc_date_range
@@ -107,7 +107,7 @@ module Macros
         range_years = []
         accumulator.each do |val|
           range_years << val.scan(AUC_REGEX).map { |year| year.sub(AUC_DELIM, '').to_i }
-          next unless range_years.flatten!.uniq!.nil?
+          next unless range_years.flatten!&.uniq!.nil?
 
           range_years << ParseDate.range_array(ParseDate.earliest_year(val), ParseDate.latest_year(val))
         end

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -99,7 +99,7 @@ module Macros
     # ---------- Collection or Metadata format specific macros below, alphabetical except for additional helper methods
 
     AUC_DELIM = ';'
-    AUC_REGEX = Regexp.new("\\d{4}#{AUC_DELIM}") # captures the `YYYY; YYYY; YYYY; YYYY;` pattern
+    AUC_REGEX = Regexp.new("\\d{4}#{AUC_DELIM}?") # captures the `YYYY; YYYY; YYYY; YYYY;` pattern
 
     # extracts dates from American University of Cairo data
     def auc_date_range
@@ -112,7 +112,7 @@ module Macros
           range_years << ParseDate.range_array(ParseDate.earliest_year(val), ParseDate.latest_year(val))
         end
 
-        range_years.flatten!.uniq! if range_years.any?
+        range_years.flatten!&.uniq!&.sort! if range_years.any?
         accumulator.replace(range_years)
       end
     end

--- a/spec/lib/traject/macros/date_parsing_spec.rb
+++ b/spec/lib/traject/macros/date_parsing_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe Macros::DateParsing do
         expect(indexer.map_record(value: '1990-1995')).to include 'range' => [1990, 1991, 1992, 1993, 1994, 1995]
         expect(indexer.map_record(value: '990-995')).to include 'range' => [990, 991, 992, 993, 994, 995]
         expect(indexer.map_record(value: '1990; 1991; 1992;')).to include 'range' => [1990, 1991, 1992]
+        expect(indexer.map_record(value: '1990; 1991; 1992')).to include 'range' => [1990, 1991, 1992]
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Closes #320 
AUC collection wasn't converting cleanly;  the problem was a date field without a trailing semicolon:

```xml
2019-11-04T18:56:15+00:00 ERROR Unexpected error on record <record #1 (data/auc/p15795coll13/data/15.xml #1), output_id:oai:cdm15795.contentdm.oclc.org:p15795coll13/88>
    while executing (to_field "cho_date_range_norm" at traject_configs/auc_config.rb:36)
    Record: <?xml version="1.0"?>
<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
snip
      <dc:date>ca. 1970s</dc:date>
      <dc:date>1970; 1971; 1972; 1973; 1974; 1975; 1976; 1977; 1978; 1979</dc:date>
 ```

This PR fixes the regular expression to allow a semicolon to be missing and fixes the final manipulation of the result array to use safe navigators.

## Was the documentation (README, API, wiki, ...) updated?
