### PR TITLE
parse_date v0.4.2 get correct date ranges for yyyy-y pattern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
-    parse_date (0.4.1)
+    parse_date (0.4.2)
       zeitwerk (~> 2.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -28,8 +28,8 @@ to_field 'cho_title', extract_json('.title'), strip, default('Untitled Item')
 to_field 'cho_creator', extract_json('.author'), strip
 to_field 'cho_contributor', extract_json('.printer'), strip, append(' [printer]')
 to_field 'cho_date', extract_json('.date_statement'), strip
-to_field 'cho_date_range_norm', extract_json('.date_statement'), strip, parse_range
-to_field 'cho_date_range_hijri', extract_json('.date_statement'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', extract_json('.date_statement'), strip, gsub('/', '-'), parse_range
+to_field 'cho_date_range_hijri', extract_json('.date_statement'), strip, gsub('/', '-'), parse_range, hijri_range
 to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html')
 to_field 'cho_description', extract_json('.description'), strip
 to_field 'cho_edm_type', literal('Text')


### PR DESCRIPTION
## Why was this change made?

See https://github.com/sul-dlss/parse_date/issues/33 -- at least 3 collections have some dates with yyyy-y pattern;  this will ensure we get correct range of years.

## Was the documentation (README, API, wiki, ...) updated?

n/a