### PR TITLE
lang macro only adds hash to accum. when it has a value

### DIFF
--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -96,7 +96,7 @@ module Macros
         Settings.acceptable_bcp47_codes.include?(bcp47_string)
 
       lambda do |_record, accumulator, _context|
-        accumulator.replace([{ language: bcp47_string, values: accumulator.dup }])
+        accumulator.replace([{ language: bcp47_string, values: accumulator.dup }]) unless accumulator&.empty?
       end
     end
 

--- a/spec/lib/traject/macros/dlme_spec.rb
+++ b/spec/lib/traject/macros/dlme_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe Macros::DLME do
       callable = instance.lang('en')
       expect(callable.call(nil, accumulator, nil)).to eq([{ language: 'en', values: accumulator_original }])
     end
+
+    context 'with no values in accumulator' do
+      it 'leaves accumulator empty' do
+        accumulator = []
+        callable = instance.lang('en')
+        expect(callable.call(nil, accumulator, nil)).to eq nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Closes #365.

Bug:  fields with transforms using `lang` macro were getting values like:

```
[{:language=>"en", :values=>[]}]
```

This fixes the bug.

## Was the documentation (README, API, wiki, ...) updated?

n/a