### PR TITLE
Do not raise exceptions for any date-parsing errors

### DIFF
--- a/lib/after_processing_config.rb
+++ b/lib/after_processing_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'exception_collector'
+
+after_processing do
+  warn "Encountered #{Dlme::ExceptionCollector.instance.count} date parsing errors:" if
+    Dlme::ExceptionCollector.instance.count.positive?
+
+  Dlme::ExceptionCollector.instance.each do |exception|
+    warn exception
+  end
+end

--- a/lib/exception_collector.rb
+++ b/lib/exception_collector.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+require 'singleton'
+
+module Dlme
+  # A singleton exception collector
+  class ExceptionCollector
+    include Singleton
+
+    def initialize
+      @exception_collector = Concurrent::Array.new
+    end
+
+    delegate :<<, :count, :each, to: :exception_collector
+
+    private
+
+    attr_reader :exception_collector
+  end
+end

--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -2,7 +2,7 @@
 
 module Macros
   # Macros for post-processing data
-  module PostProcess
+  module EachRecord
     # Converts one or more fields from arrays or strings into hashes with language codes
     # @example
     #   convert_to_language_hash => lambda { ... }

--- a/lib/transformer.rb
+++ b/lib/transformer.rb
@@ -29,6 +29,7 @@ module Dlme
       @transformer ||= Traject::Indexer.new.tap do |indexer|
         config_filepaths.each { |config_filepath| indexer.load_config_file(config_filepath) }
         indexer.load_config_file('lib/record_counter_config.rb')
+        indexer.load_config_file('lib/after_processing_config.rb')
         indexer.settings do
           provide 'command_line.filename', this.input_filepath
           provide 'close_output_on_close', false

--- a/spec/integration/traject_configs_spec.rb
+++ b/spec/integration/traject_configs_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe 'integration with Traject configs' do
           config_filepaths: config['trajects'].map { |traject| "#{Settings.defaults.traject_dir}/#{traject}" },
           settings: config.fetch('settings', {})
         ).transform
+      rescue StandardError => e
+        raise "error raised mapping #{config['settings']['inst_id']}: #{e.class}: #{e.message}"
       end
-    end.not_to raise_error(RuntimeError)
+    end.not_to raise_error
   end
 end

--- a/spec/lib/traject/macros/each_record_spec.rb
+++ b/spec/lib/traject/macros/each_record_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'macros/post_process'
+require 'macros/each_record'
 
-RSpec.describe Macros::PostProcess do
+RSpec.describe Macros::EachRecord do
   let(:klass) do
     Class.new do
       include TrajectPlus::Macros
-      include Macros::PostProcess
+      include Macros::EachRecord
     end
   end
   let(:instance) { klass.new }

--- a/traject_configs/aims_config.rb
+++ b/traject_configs/aims_config.rb
@@ -4,13 +4,13 @@ require 'dlme_json_resource_writer'
 require 'macros/aims'
 require 'macros/date_parsing'
 require 'macros/dlme'
-require 'macros/post_process'
+require 'macros/each_record'
 require 'traject_plus'
 
 extend Macros::AIMS
-extend Macros::DateParsing
 extend Macros::DLME
-extend Macros::PostProcess
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 
 settings do

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -3,18 +3,18 @@
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/oai'
-require 'macros/post_process'
 require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
 extend Macros::OAI
-extend Macros::PostProcess
 extend TrajectPlus::Macros
 
 settings do

--- a/traject_configs/auc_common_config.rb
+++ b/traject_configs/auc_common_config.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/string/inflections'
-require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/oai'
-require 'macros/content_dm'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DateParsing
-extend Macros::PostProcess
-extend Macros::DLME
-extend Macros::OAI
 extend Macros::ContentDm
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::OAI
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml
 

--- a/traject_configs/bnf_common_config.rb
+++ b/traject_configs/bnf_common_config.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/srw'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::DateParsing
-extend TrajectPlus::Macros
+extend Macros::EachRecord
 extend Macros::SRW
+extend TrajectPlus::Macros
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
-require 'macros/post_process'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
-extend Macros::PostProcess
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 

--- a/traject_configs/cambridge_config.rb
+++ b/traject_configs/cambridge_config.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/tei'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
-extend Macros::PostProcess
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::Tei
 extend TrajectPlus::Macros
-extend TrajectPlus::Macros::Xml
 extend TrajectPlus::Macros::Tei
+extend TrajectPlus::Macros::Xml
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/cluster_config.rb
+++ b/traject_configs/cluster_config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/date_parsing'
-require 'macros/post_process'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 

--- a/traject_configs/csv_config.rb
+++ b/traject_configs/csv_config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/csv'
 require 'macros/dlme'
-require 'macros/post_process'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
-extend Macros::DLME
 extend Macros::Csv
+extend Macros::DLME
+extend Macros::EachRecord
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/fgdc_config.rb
+++ b/traject_configs/fgdc_config.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/fgdc'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::FGDC
-extend Macros::PostProcess
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::FGDC
 extend TrajectPlus::Macros::Xml

--- a/traject_configs/harvard_ihp_config.rb
+++ b/traject_configs/harvard_ihp_config.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/harvard'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
-extend Macros::PostProcess
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::Harvard
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml

--- a/traject_configs/iiif_config.rb
+++ b/traject_configs/iiif_config.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
-require 'macros/post_process'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::DLME
+extend Macros::EachRecord
 extend TrajectPlus::Macros::JSON
 
 settings do

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'traject/macros/marc21_semantics'
-require 'traject/macros/marc_format_classifier'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
-require 'macros/post_process'
+require 'macros/each_record'
+require 'traject/macros/marc21_semantics'
+require 'traject/macros/marc_format_classifier'
 
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
 extend Macros::DlmeMarc
-extend Macros::PostProcess
+extend Macros::EachRecord
 extend Traject::Macros::Marc21
 extend Traject::Macros::Marc21Semantics
 extend Traject::Macros::MarcFormats

--- a/traject_configs/met_config.rb
+++ b/traject_configs/met_config.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/met'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::PostProcess
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::Met
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
-extend Macros::Met
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/michigan_config.rb
+++ b/traject_configs/michigan_config.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/michigan'
 require 'macros/oai'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::Michigan
 extend Macros::OAI
-extend Macros::PostProcess
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml
 

--- a/traject_configs/mods_config.rb
+++ b/traject_configs/mods_config.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/mods'
 require 'macros/normalize_type'
 require 'macros/stanford'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DateParsing
-extend Macros::PostProcess
 extend Macros::DLME
-extend TrajectPlus::Macros
-extend TrajectPlus::Macros::Xml
-extend TrajectPlus::Macros::Mods
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::IIIF
 extend Macros::Mods
 extend Macros::NormalizeType
-extend Macros::IIIF
 extend Macros::Stanford
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Mods
+extend TrajectPlus::Macros::Xml
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
-# Numismatics CSV Mapping Configuration
-
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/csv'
-require 'macros/numismatic_csv'
 require 'macros/date_parsing'
-require 'macros/post_process'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/numismatic_csv'
+require 'traject_plus'
 
-extend Macros::PostProcess
-extend Macros::DLME
 extend Macros::Csv
+extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::NumismaticCsv
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
-extend Macros::NumismaticCsv
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/openn_common_config.rb
+++ b/traject_configs/openn_common_config.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/normalize_language'
-require 'macros/post_process'
 require 'macros/tei'
+require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
-extend Macros::PostProcess
-extend Macros::Tei
+extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::Tei
 extend TrajectPlus::Macros
-extend TrajectPlus::Macros::Xml
 extend TrajectPlus::Macros::Tei
+extend TrajectPlus::Macros::Xml
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/normalize_type'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::DLME
 extend Macros::Csv
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::NormalizeType
-extend Macros::PostProcess
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 

--- a/traject_configs/pppa_config.rb
+++ b/traject_configs/pppa_config.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
-require 'macros/date_parsing'
 require 'macros/csv'
-require 'macros/post_process'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
-extend Macros::DLME
 extend Macros::Csv
+extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 

--- a/traject_configs/princeton_movie_config.rb
+++ b/traject_configs/princeton_movie_config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/date_parsing'
-require 'macros/post_process'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 

--- a/traject_configs/princeton_mss_config.rb
+++ b/traject_configs/princeton_mss_config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/date_parsing'
-require 'macros/post_process'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 

--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
 require 'macros/qnl'
-require 'macros/post_process'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::DateParsing
-extend TrajectPlus::Macros
+extend Macros::EachRecord
 extend Macros::QNL
+extend TrajectPlus::Macros
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
-require 'macros/oai'
+require 'macros/each_record'
 require 'macros/normalize_type'
-require 'macros/content_dm'
-require 'macros/post_process'
+require 'macros/oai'
+require 'traject_plus'
 
-extend Macros::PostProcess
 extend Macros::ContentDm
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
 extend Macros::NormalizeType
 extend Macros::OAI
 extend TrajectPlus::Macros

--- a/traject_configs/stanford_mods_config.rb
+++ b/traject_configs/stanford_mods_config.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require 'macros/dlme'
-require 'macros/post_process'
+require 'macros/each_record'
 
 extend Macros::DLME
+extend Macros::EachRecord
 extend Macros::IIIF
-extend Macros::PostProcess
 
 each_record do |record, context|
   context.clipboard[:druid] = generate_druid(record, context)

--- a/traject_configs/yale_medical_config.rb
+++ b/traject_configs/yale_medical_config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/csv'
-require 'macros/post_process'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'traject_plus'
 
-extend Macros::PostProcess
-extend Macros::DLME
 extend Macros::Csv
+extend Macros::DLME
+extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 


### PR DESCRIPTION
Fixes #325

## Why was this change made?

Collect date-parsing errors as transformations run and then log them at the end of the run. This way, @jacobthill can see more clearly which datasets need changes, without bombing a whole batch.

Also includes:
* Bump `parse_date` to 0.4.2 so that year range exceptions come back as `ParseDate::Error` rather than `StandardError`.
* Rename `PostProcess` macros to `EachRecord` to distinguish them from the `after_processing` code
* Let integration specs fail if any exceptions are raised so we can find errors sooner as we go forward.

## Was the documentation (README, API, wiki, ...) updated?

No.