### PR TITLE
refactor: greatly simplify add_cho_type_facet macro

### DIFF
--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -3,66 +3,8 @@
 module Macros
   # Macros for post-processing data
   module EachRecord
-    # NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-    # NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-    # create cho_type_facet values from cho_edm_type and cho_has_type values,
-    # add to context.output_hash if there's a value
-    def add_cho_type_facet
-      lambda do |_record, context|
-        context.output_hash['cho_type_facet'] = {}
-        context.output_hash['cho_edm_type']&.each do |el|
-          if el.is_a?(Hash)
-            lang_code = el[:language]
-            val = cho_type_facet_val_from_hash(context, lang_code) if lang_code
-            context.output_hash['cho_type_facet'][lang_code] = [val] if val.present?
-          else
-            val = cho_type_facet_val_from_array(context)
-            context.output_hash['cho_type_facet']['none'] = [val] if val.present?
-          end
-        end
-        context.output_hash.delete('cho_type_facet') if context.output_hash['cho_type_facet'].empty?
-      end
-    end
-
-    # helper method for add_cho_type_facet
-    # @return [String or nil]
-    def cho_type_facet_val_from_hash(context, lang_code)
-      edm_type = lang_hash_value(context, 'cho_edm_type', lang_code)
-      has_type_val = context.output_hash['cho_has_type']&.first
-      has_type = lang_hash_value(context, 'cho_has_type', lang_code) if has_type_val.is_a?(Hash)
-      hierarchical_val(edm_type, has_type)
-    end
-
-    # helper method for add_cho_type_facet
-    # @return [String or nil]
-    def cho_type_facet_val_from_array(context)
-      edm_type = array_value(context, 'cho_edm_type')
-      has_type_val = context.output_hash['cho_has_type']&.first
-      has_type = array_value(context, 'cho_has_type') if has_type_val.is_a?(String)
-      hierarchical_val(edm_type, has_type)
-    end
-
-    # helper method for add_cho_type_facet
-    # @return [String or nil]
-    def hierarchical_val(first, second)
-      result = first if first.present?
-      result = "#{result}:#{second}" if result && second.present?
-      result
-    end
-
-    # helper method for add_cho_type_facet
-    def array_value(context, field)
-      raw_val = context.output_hash[field]
-      raw_val&.first
-    end
-
-    # helper method for add_cho_type_facet
-    def lang_hash_value(context, field, lang_code)
-      lang_hash = context.output_hash[field]&.select { |el| el[:language] == lang_code }
-      lang_hash.first[:values]&.first
-    end
-
     # Converts one or more fields from arrays or strings into hashes with language codes
+    # NOTE: do *not* include cho_type_facet in fields list
     # @example
     #   convert_to_language_hash => lambda { ... }
     # @return [Proc] a proc that traject can call for each record
@@ -83,6 +25,33 @@ module Macros
           context.output_hash[key] = result
         end
       end
+    end
+
+    # NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+    #   (do *not* include cho_type_facet in convert_to_language_hash fields)
+    # Adds cho_type_facet field to context.output_hash (but only if there's a value).
+    #   Create cho_type_facet hierarchical values for each language present (including 'none')
+    # NOTE: we anticipate only one value for each language.
+    def add_cho_type_facet
+      lambda do |_record, context|
+        context.output_hash['cho_type_facet'] = {}
+        cho_has_type_raw_hash = context.output_hash['cho_has_type']
+        context.output_hash['cho_edm_type']&.each_pair do |lang, values|
+          edm_type_first = values&.first
+          has_type_first = cho_has_type_raw_hash[lang]&.first if cho_has_type_raw_hash
+          val = hierarchical_val(edm_type_first, has_type_first)
+          context.output_hash['cho_type_facet'][lang] = [val] if val.present?
+        end
+        context.output_hash.delete('cho_type_facet') if context.output_hash['cho_type_facet'].empty?
+      end
+    end
+
+    HIER_LEVEL_SEP_CHAR = ':'
+
+    # helper method for add_cho_type_facet
+    # @return [String or nil]
+    def hierarchical_val(*values)
+      values.compact.join(HIER_LEVEL_SEP_CHAR)
     end
   end
 end

--- a/traject_configs/aims_config.rb
+++ b/traject_configs/aims_config.rb
@@ -57,10 +57,6 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -91,3 +87,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_aladab_config.rb
+++ b/traject_configs/aub_aladab_config.rb
@@ -17,10 +17,6 @@ to_field 'cho_publisher', literal('Dar al-Adab'), lang('en')
 to_field 'cho_publisher', literal('دار الأدب'), lang('ar-Arab')
 to_field 'cho_subject', extract_oai('dc:subject'), strip, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'cho_contributor',
   'cho_creator',
@@ -32,3 +28,6 @@ each_record convert_to_language_hash(
   'cho_subject',
   'cho_title'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_postcards_config.rb
+++ b/traject_configs/aub_postcards_config.rb
@@ -12,10 +12,6 @@ to_field 'cho_has_type', literal('Postcard'), lang('en')
 to_field 'cho_has_type', literal('Postcard'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_subject', extract_oai('dc:subject'), strip, lang('en')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'cho_contributor',
   'cho_dc_rights',
@@ -24,3 +20,6 @@ each_record convert_to_language_hash(
   'cho_subject',
   'cho_title'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/auc_common_config.rb
+++ b/traject_configs/auc_common_config.rb
@@ -75,10 +75,6 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -109,3 +105,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/bnf_ideo_config.rb
+++ b/traject_configs/bnf_ideo_config.rb
@@ -8,13 +8,12 @@ to_field 'cho_edm_type', extract_srw('dc:type'),
          first_only, strip, transform(&:downcase), translation_map('not_found', 'types', 'french-types')
 to_field 'cho_language', extract_srw('dc:language'), first_only, strip, translation_map('marc_languages')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'cho_contributor',
   'cho_creator',
   'cho_edm_type',
   'cho_language'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/bnf_ifao_config.rb
+++ b/traject_configs/bnf_ifao_config.rb
@@ -8,13 +8,12 @@ to_field 'cho_edm_type', extract_srw('dc:type'),
          default('notated music'), first_only, strip, transform(&:downcase), translation_map('not_found', 'types', 'french-types')
 to_field 'cho_language', extract_srw('dc:language'), first_only, strip, translation_map('marc_languages')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'cho_contributor',
   'cho_creator',
   'cho_edm_type',
   'cho_language'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -59,10 +59,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -93,3 +89,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/cambridge_config.rb
+++ b/traject_configs/cambridge_config.rb
@@ -85,10 +85,6 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -119,3 +115,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/cluster_config.rb
+++ b/traject_configs/cluster_config.rb
@@ -55,10 +55,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -89,3 +85,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/fgdc_config.rb
+++ b/traject_configs/fgdc_config.rb
@@ -100,10 +100,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -134,3 +130,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/harvard_ihp_config.rb
+++ b/traject_configs/harvard_ihp_config.rb
@@ -65,10 +65,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -99,3 +95,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -129,3 +129,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 #   'cho_title',
 #   'cho_type'
 # )
+#
+# # NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+# each_record add_cho_type_facet

--- a/traject_configs/met_config.rb
+++ b/traject_configs/met_config.rb
@@ -79,10 +79,6 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -113,3 +109,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/michigan_config.rb
+++ b/traject_configs/michigan_config.rb
@@ -35,8 +35,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   )
 end
 
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -67,3 +65,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -69,10 +69,6 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -103,3 +99,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/openn_common_config.rb
+++ b/traject_configs/openn_common_config.rb
@@ -77,10 +77,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -111,3 +107,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -74,10 +74,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -108,3 +104,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/pppa_config.rb
+++ b/traject_configs/pppa_config.rb
@@ -55,10 +55,6 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -89,3 +85,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/princeton_movie_config.rb
+++ b/traject_configs/princeton_movie_config.rb
@@ -59,10 +59,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -93,3 +89,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/princeton_mss_config.rb
+++ b/traject_configs/princeton_mss_config.rb
@@ -66,10 +66,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -100,3 +96,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -56,10 +56,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -90,3 +86,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -67,10 +67,6 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_country',
@@ -101,3 +97,6 @@ each_record convert_to_language_hash(
   'cho_title',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/stanford_mods_config.rb
+++ b/traject_configs/stanford_mods_config.rb
@@ -77,12 +77,11 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
-# NOTE: compute cho_type_facet BEFORE calling convert_to_language_hash fields
-# NOTE: do *not* include cho_type_facet in convert_to_language_hash fields
-each_record add_cho_type_facet
-
 each_record convert_to_language_hash(
   'agg_data_provider_country',
   'agg_provider_country',
   'cho_type'
 )
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet


### PR DESCRIPTION
## Why was this change made?

My first implementation of `add_cho_type_facet` macro was functional but somewhat tortured.  The goal of this PR is to make the code easier to understand and maintain.

## Was the documentation (README, API, wiki, ...) updated?

n/a unless you count method comments.