### PR TITLE
Return first value in addition to joined value for hierarchical facet values

### DIFF
--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -40,7 +40,7 @@ module Macros
           edm_type_first = values&.first
           has_type_first = cho_has_type_raw_hash[lang]&.first if cho_has_type_raw_hash
           val = hierarchical_val(edm_type_first, has_type_first)
-          context.output_hash['cho_type_facet'][lang] = [val] if val.present?
+          context.output_hash['cho_type_facet'][lang] = val if val.present?
         end
         context.output_hash.delete('cho_type_facet') if context.output_hash['cho_type_facet'].empty?
       end
@@ -51,7 +51,10 @@ module Macros
     # helper method for add_cho_type_facet
     # @return [String or nil]
     def hierarchical_val(*values)
-      values.compact.join(HIER_LEVEL_SEP_CHAR)
+      non_nil_values = values.compact
+      return non_nil_values if non_nil_values.count < 2
+
+      [non_nil_values.first, non_nil_values.join(HIER_LEVEL_SEP_CHAR)]
     end
   end
 end

--- a/spec/lib/traject/macros/each_record_spec.rb
+++ b/spec/lib/traject/macros/each_record_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Macros::EachRecord do
 
       it 'creates values for each language' do
         macro.call(nil, mock_context)
-        expect(mock_context.output_hash).to include('cho_type_facet' => { 'en' => ['Sound:Interview'],
-                                                                          'ar-Arab' => ['صوت:مقابلة'] })
+        expect(mock_context.output_hash).to include('cho_type_facet' => { 'en' => ['Sound', 'Sound:Interview'],
+                                                                          'ar-Arab' => ['صوت', 'صوت:مقابلة'] })
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe Macros::EachRecord do
 
       it 'creates value for "none" language' do
         macro.call(nil, mock_context)
-        expect(mock_context.output_hash).to include('cho_type_facet' => { 'none' => ['Sound:Interview'] })
+        expect(mock_context.output_hash).to include('cho_type_facet' => { 'none' => ['Sound', 'Sound:Interview'] })
       end
     end
 


### PR DESCRIPTION
Fixes #390

## Why was this change made?

To feed `blacklight-hierarchy` the values it expects.

## Was the documentation (README, API, wiki, ...) updated?

no.