### PR TITLE
Fix language mapping error in Michigan collection, fixes #351

### DIFF
--- a/lib/macros/normalize_language.rb
+++ b/lib/macros/normalize_language.rb
@@ -10,7 +10,7 @@ module Macros
                     iso_639-1
                     iso_639-2
                     iso_639-3
-                    auc-languages-errors].freeze
+                    language-errors].freeze
 
     # Maps extracted language values to a series of tranlation maps
     # @example

--- a/lib/translation_maps/language-errors.yaml
+++ b/lib/translation_maps/language-errors.yaml
@@ -1,3 +1,8 @@
 # Errors: map to nothing to pass not_found test
+
+# AUC
 eg:
 englishglish:
+
+# Michigan
+aratur:

--- a/lib/translation_maps/languages.yaml
+++ b/lib/translation_maps/languages.yaml
@@ -8,6 +8,7 @@ amharic: Amharic
 arabic: Arabic
 aragonese: Aragonese
 aramaic: Aramaic
+aratur: Aratur
 armenian: Armenian
 assamese: Assamese
 avaric: Avaric

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -5,6 +5,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
 require 'macros/each_record'
+require 'macros/normalize_language'
 require 'traject/macros/marc21_semantics'
 require 'traject/macros/marc_format_classifier'
 require 'traject_plus'
@@ -13,6 +14,7 @@ extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::DlmeMarc
 extend Macros::EachRecord
+extend Macros::NormalizeLanguage
 extend Traject::Macros::Marc21
 extend Traject::Macros::Marc21Semantics
 extend Traject::Macros::MarcFormats
@@ -60,8 +62,8 @@ to_field 'cho_format', marc_formats, lang('en')
 to_field 'cho_identifier', oclcnum
 to_field 'cho_is_part_of', extract_marc('440a:490a:800abcdt:400abcd:810abcdt:410abcd:811acdeft:411acdef:830adfgklmnoprst:760ast', alternate_script: false), lang('en')
 to_field 'cho_is_part_of', extract_marc('440a:490a:800abcdt:400abcd:810abcdt:410abcd:811acdeft:411acdef:830adfgklmnoprst:760ast', alternate_script: :only), lang('ar-Arab')
-to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), transform(&:downcase), translation_map('not_found', 'marc_languages', 'iso_639-2'), lang('en')
-to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), transform(&:downcase), translation_map('not_found', 'marc_languages', 'iso_639-2'), translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), normalize_language, lang('en')
+to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
 # to_field 'cho_medium'
 # fo_field 'cho_provenance'
 to_field 'cho_publisher', extract_marc('260b:264b', alternate_script: false), trim_punctuation, lang('en')


### PR DESCRIPTION
## Why was this change made?

- Use normalize_language macro for language extraction

- Fix some mapping errors in Michigan language values

## Was the documentation (README, API, wiki, ...) updated?

-n/a