### PR TITLE
Add transform_version and transform_timestamp to IR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_URL
 
+ENV VERSION=$VCS_REF
+
 LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.build-date=$BUILD_DATE \

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,8 @@ fields:
       - agg_is_shown_at
       - agg_is_shown_by
       - agg_preview
+      - transform_version
+      - transform_timestamp
     web_resources:
       - agg_is_shown_at
       - agg_is_shown_by

--- a/lib/contracts/cho.rb
+++ b/lib/contracts/cho.rb
@@ -36,6 +36,8 @@ module Contracts
       optional(:cho_type_facet).value(:hash?)
 
       # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#oreaggregation
+      required(:transform_version).filled(:string)
+      required(:transform_timestamp).filled(:string)
       required(:id).filled(:string)
       optional('__source'.to_sym).filled(:string)
       # Since the IR is a flattened projection of the MAP, 'agg_aggregated_cho' is not used.

--- a/lib/contracts/cho.rb
+++ b/lib/contracts/cho.rb
@@ -36,8 +36,8 @@ module Contracts
       optional(:cho_type_facet).value(:hash?)
 
       # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#oreaggregation
-      required(:transform_version).filled(:string)
-      required(:transform_timestamp).filled(:string)
+      # required(:transform_version).filled(:string)
+      # required(:transform_timestamp).filled(:string)
       required(:id).filled(:string)
       optional('__source'.to_sym).filled(:string)
       # Since the IR is a flattened projection of the MAP, 'agg_aggregated_cho' is not used.

--- a/lib/macros/timestamp.rb
+++ b/lib/macros/timestamp.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Macros
+  # Macro for setting the transform_version to the proper github hash
+  module Timestamp
+    # Sets a literal to the current timestamp
+    # @return [Proc] a proc that traject can call for each record
+    def timestamp
+      lambda do |_, accumulator|
+        accumulator << Time.now
+      end
+    end
+  end
+end

--- a/lib/macros/version.rb
+++ b/lib/macros/version.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Macros
+  # Macro for setting the transform_version to the proper github hash
+  module Version
+    # Sets a literal to the current Github hash from the environment
+    #   if it's available (for the docker image)
+    # @return [Proc] a proc that traject can call for each record
+    def version
+      lambda do |_, accumulator|
+        accumulator << `git rev-parse --short HEAD`.strip unless ENV['VERSION']
+        accumulator << ENV['VERSION']
+      end
+    end
+  end
+end

--- a/lib/macros/version.rb
+++ b/lib/macros/version.rb
@@ -8,8 +8,7 @@ module Macros
     # @return [Proc] a proc that traject can call for each record
     def version
       lambda do |_, accumulator|
-        accumulator << `git rev-parse --short HEAD`.strip unless ENV['VERSION']
-        accumulator << ENV['VERSION']
+        accumulator << ENV.fetch('VERSION', `git rev-parse --short HEAD`.strip)
       end
     end
   end

--- a/spec/lib/traject/macros/timestamp_spec.rb
+++ b/spec/lib/traject/macros/timestamp_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'macros/timestamp'
+
+RSpec.describe Macros::Timestamp do
+  let(:klass) do
+    Class.new do
+      include Macros::Timestamp
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe '#timestamp' do
+    let(:time_now) { Time.now }
+    it 'returns a timestamp value' do
+      allow(Time).to receive(:now).and_return(time_now)
+      callable = instance.timestamp
+      expect(callable.call(nil, [])).to eq([time_now])
+    end
+  end
+end

--- a/spec/lib/traject/macros/version_spec.rb
+++ b/spec/lib/traject/macros/version_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'macros/version'
+
+RSpec.describe Macros::Version do
+  let(:klass) do
+    Class.new do
+      include Macros::Version
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe '#version' do
+    let(:version) { '8bb2a18' }
+    it 'returns a github hash key from the environment' do
+      allow(ENV).to receive(:[]).with('VERSION').and_return(version)
+      callable = instance.version
+      expect(callable.call(nil, [])).to eq([version])
+    end
+  end
+end

--- a/spec/lib/traject/macros/version_spec.rb
+++ b/spec/lib/traject/macros/version_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Macros::Version do
   describe '#version' do
     let(:version) { '8bb2a18' }
     it 'returns a github hash key from the environment' do
-      allow(ENV).to receive(:[]).with('VERSION').and_return(version)
+      allow(ENV).to receive(:fetch).and_return(version)
       callable = instance.version
       expect(callable.call(nil, [])).to eq([version])
     end

--- a/traject_configs/aims_config.rb
+++ b/traject_configs/aims_config.rb
@@ -5,18 +5,26 @@ require 'macros/aims'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::AIMS
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', extract_aims('guid'), strip

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -7,6 +7,8 @@ require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/oai'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
@@ -15,12 +17,18 @@ extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
 extend Macros::OAI
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_oai_identifier, strip

--- a/traject_configs/auc_common_config.rb
+++ b/traject_configs/auc_common_config.rb
@@ -9,6 +9,8 @@ require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/oai'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::ContentDm
@@ -18,6 +20,8 @@ extend Macros::EachRecord
 extend Macros::OAI
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml
 
@@ -25,6 +29,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_oai_identifier, strip

--- a/traject_configs/bnf_common_config.rb
+++ b/traject_configs/bnf_common_config.rb
@@ -7,6 +7,8 @@ require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/srw'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DateParsing
@@ -15,12 +17,18 @@ extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
 extend Macros::SRW
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 
 settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_srw('dc:identifier'), strip

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
+require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/normalize_language'
 require 'macros/timestamp'
 require 'macros/version'
-require 'traject_plus'
 
-extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::DLME
 extend Macros::EachRecord
+extend Macros::NormalizeLanguage
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -33,22 +35,27 @@ to_field 'id', extract_json('.thumbnail'),
 to_field 'cho_title', extract_json('.title'), strip, default('Untitled Item')
 
 # Cho Other
-to_field 'cho_creator', extract_json('.author'), strip
-to_field 'cho_contributor', extract_json('.printer'), strip, append(' [printer]')
-to_field 'cho_date', extract_json('.date_statement'), strip
+to_field 'cho_creator', extract_json('.author'), strip, lang('en')
+to_field 'cho_contributor', extract_json('.printer'), strip, append(' [printer]'), lang('en')
+to_field 'cho_date', extract_json('.date_statement'), strip, lang('en')
 to_field 'cho_date_range_norm', extract_json('.date_statement'), strip, gsub('/', '-'), parse_range
 to_field 'cho_date_range_hijri', extract_json('.date_statement'), strip, gsub('/', '-'), parse_range, hijri_range
-to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html')
-to_field 'cho_description', extract_json('.description'), strip
-to_field 'cho_edm_type', literal('Text')
+to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html'), lang('en')
+to_field 'cho_description', extract_json('.description'), strip, lang('en')
+to_field 'cho_edm_type', literal('Text'), lang('en')
+to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Manuscript'), lang('en')
+to_field 'cho_has_type', literal('Manuscript'), translation_map('norm_types_to_ar'), lang('ar-Arab')
+to_field 'cho_identifier', extract_json('.catalogue_identifier'), strip
+to_field 'cho_language', extract_json('.language'), strip, transform(&:downcase), normalize_language, lang('en')
+to_field 'cho_language', extract_json('.language'), strip, transform(&:downcase), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
 to_field 'cho_spatial', extract_json('.place_of_origin'), strip, prepend('Place of Origin: ')
-to_field 'cho_language', extract_json('.language'), strip, transform(&:downcase), translation_map('not_found', 'languages')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
 to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
-to_field 'agg_provider', provider, lang('en')
-to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
@@ -61,11 +68,10 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_json('.thumbnail'), strip]
   )
 end
-
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
-to_field 'agg_data_provider_country', data_provider_country, lang('en')
-to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
-require 'macros/normalize_language'
+require 'macros/timestamp'
+require 'macros/version'
+require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
 extend Macros::EachRecord
-extend Macros::NormalizeLanguage
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -18,6 +20,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_json('.thumbnail'),
@@ -27,27 +33,22 @@ to_field 'id', extract_json('.thumbnail'),
 to_field 'cho_title', extract_json('.title'), strip, default('Untitled Item')
 
 # Cho Other
-to_field 'cho_creator', extract_json('.author'), strip, lang('en')
-to_field 'cho_contributor', extract_json('.printer'), strip, append(' [printer]'), lang('en')
-to_field 'cho_date', extract_json('.date_statement'), strip, lang('en')
+to_field 'cho_creator', extract_json('.author'), strip
+to_field 'cho_contributor', extract_json('.printer'), strip, append(' [printer]')
+to_field 'cho_date', extract_json('.date_statement'), strip
 to_field 'cho_date_range_norm', extract_json('.date_statement'), strip, gsub('/', '-'), parse_range
 to_field 'cho_date_range_hijri', extract_json('.date_statement'), strip, gsub('/', '-'), parse_range, hijri_range
-to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html'), lang('en')
-to_field 'cho_description', extract_json('.description'), strip, lang('en')
-to_field 'cho_edm_type', literal('Text'), lang('en')
-to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
-to_field 'cho_has_type', literal('Manuscript'), lang('en')
-to_field 'cho_has_type', literal('Manuscript'), translation_map('norm_types_to_ar'), lang('ar-Arab')
-to_field 'cho_identifier', extract_json('.catalogue_identifier'), strip
-to_field 'cho_language', extract_json('.language'), strip, transform(&:downcase), normalize_language, lang('en')
-to_field 'cho_language', extract_json('.language'), strip, transform(&:downcase), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html')
+to_field 'cho_description', extract_json('.description'), strip
+to_field 'cho_edm_type', literal('Text')
 to_field 'cho_spatial', extract_json('.place_of_origin'), strip, prepend('Place of Origin: ')
+to_field 'cho_language', extract_json('.language'), strip, transform(&:downcase), translation_map('not_found', 'languages')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
 to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
-to_field 'agg_data_provider_country', data_provider_country, lang('en')
-to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
@@ -60,10 +61,11 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_json('.thumbnail'), strip]
   )
 end
-to_field 'agg_provider', provider, lang('en')
-to_field 'agg_provider', provider_ar, lang('ar-Arab')
+
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/cambridge_config.rb
+++ b/traject_configs/cambridge_config.rb
@@ -6,6 +6,8 @@ require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/tei'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DateParsing
@@ -13,6 +15,8 @@ extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::Tei
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Tei
 extend TrajectPlus::Macros::Xml
@@ -21,6 +25,10 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Shortcut variables
 FACSIMILE = '//tei:facsimile'

--- a/traject_configs/cluster_config.rb
+++ b/traject_configs/cluster_config.rb
@@ -4,11 +4,15 @@ require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -16,6 +20,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_json('.url'), strip

--- a/traject_configs/csv_config.rb
+++ b/traject_configs/csv_config.rb
@@ -4,16 +4,24 @@ require 'dlme_json_resource_writer'
 require 'macros/csv'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Csv
 extend Macros::DLME
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # MET Museum
 to_field 'id', column('Object ID')

--- a/traject_configs/fgdc_config.rb
+++ b/traject_configs/fgdc_config.rb
@@ -5,12 +5,16 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/fgdc'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
 extend Macros::FGDC
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::FGDC
 extend TrajectPlus::Macros::Xml
@@ -19,6 +23,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Record Identifier
 to_field 'id', generate_fgdc_id(prefixed: true)

--- a/traject_configs/harvard_ihp_config.rb
+++ b/traject_configs/harvard_ihp_config.rb
@@ -5,12 +5,16 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/harvard'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
 extend Macros::Harvard
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml
 
@@ -18,6 +22,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_harvard_identifier, strip

--- a/traject_configs/iiif_config.rb
+++ b/traject_configs/iiif_config.rb
@@ -3,16 +3,24 @@
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros::JSON
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 to_field 'id', lambda { |_record, accumulator, context|
   identifier = default_identifier(context)

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -5,6 +5,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
 require 'macros/each_record'
+require 'macros/normalize_language'
 require 'macros/timestamp'
 require 'macros/version'
 require 'traject/macros/marc21_semantics'
@@ -15,6 +16,7 @@ extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::DlmeMarc
 extend Macros::EachRecord
+extend Macros::NormalizeLanguage
 extend Macros::Timestamp
 extend Macros::Version
 extend Traject::Macros::Marc21
@@ -68,8 +70,8 @@ to_field 'cho_format', marc_formats, lang('en')
 to_field 'cho_identifier', oclcnum
 to_field 'cho_is_part_of', extract_marc('440a:490a:800abcdt:400abcd:810abcdt:410abcd:811acdeft:411acdef:830adfgklmnoprst:760ast', alternate_script: false), lang('en')
 to_field 'cho_is_part_of', extract_marc('440a:490a:800abcdt:400abcd:810abcdt:410abcd:811acdeft:411acdef:830adfgklmnoprst:760ast', alternate_script: :only), lang('ar-Arab')
-to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), transform(&:downcase), translation_map('not_found', 'marc_languages', 'iso_639-2'), lang('en')
-to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), transform(&:downcase), translation_map('not_found', 'marc_languages', 'iso_639-2'), translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), normalize_language, lang('en')
+to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
 # to_field 'cho_medium'
 # fo_field 'cho_provenance'
 to_field 'cho_publisher', extract_marc('260b:264b', alternate_script: false), trim_punctuation, lang('en')

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -5,7 +5,8 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
 require 'macros/each_record'
-require 'macros/normalize_language'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject/macros/marc21_semantics'
 require 'traject/macros/marc_format_classifier'
 require 'traject_plus'
@@ -14,7 +15,8 @@ extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::DlmeMarc
 extend Macros::EachRecord
-extend Macros::NormalizeLanguage
+extend Macros::Timestamp
+extend Macros::Version
 extend Traject::Macros::Marc21
 extend Traject::Macros::Marc21Semantics
 extend Traject::Macros::MarcFormats
@@ -28,6 +30,10 @@ settings do
   # provide "reader_class_name", "MarcReader"
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', extract_marc('001'), first_only
@@ -62,8 +68,8 @@ to_field 'cho_format', marc_formats, lang('en')
 to_field 'cho_identifier', oclcnum
 to_field 'cho_is_part_of', extract_marc('440a:490a:800abcdt:400abcd:810abcdt:410abcd:811acdeft:411acdef:830adfgklmnoprst:760ast', alternate_script: false), lang('en')
 to_field 'cho_is_part_of', extract_marc('440a:490a:800abcdt:400abcd:810abcdt:410abcd:811acdeft:411acdef:830adfgklmnoprst:760ast', alternate_script: :only), lang('ar-Arab')
-to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), normalize_language, lang('en')
-to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), transform(&:downcase), translation_map('not_found', 'marc_languages', 'iso_639-2'), lang('en')
+to_field 'cho_language', extract_marc('008[35-37]:041a:041d'), transform(&:downcase), translation_map('not_found', 'marc_languages', 'iso_639-2'), translation_map('norm_languages_to_ar'), lang('ar-Arab')
 # to_field 'cho_medium'
 # fo_field 'cho_provenance'
 to_field 'cho_publisher', extract_marc('260b:264b', alternate_script: false), trim_punctuation, lang('en')

--- a/traject_configs/met_config.rb
+++ b/traject_configs/met_config.rb
@@ -5,12 +5,16 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/met'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::Met
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -20,6 +24,10 @@ settings do
 end
 
 # Note: Met JSON uses blanks ("") instead of nulls.
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', extract_json('.objectID'), lambda { |_record, accumulator, context|

--- a/traject_configs/mods_config.rb
+++ b/traject_configs/mods_config.rb
@@ -7,6 +7,8 @@ require 'macros/each_record'
 require 'macros/mods'
 require 'macros/normalize_type'
 require 'macros/stanford'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
@@ -16,6 +18,8 @@ extend Macros::IIIF
 extend Macros::Mods
 extend Macros::NormalizeType
 extend Macros::Stanford
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Mods
 extend TrajectPlus::Macros::Xml
@@ -24,6 +28,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Spotlight DLME IR Record Identifier
 to_field 'id', generate_mods_id

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -6,6 +6,8 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/numismatic_csv'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Csv
@@ -13,6 +15,8 @@ extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
 extend Macros::NumismaticCsv
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 
@@ -20,6 +24,10 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', normalize_prefixed_id('RecordId')

--- a/traject_configs/openn_common_config.rb
+++ b/traject_configs/openn_common_config.rb
@@ -6,13 +6,17 @@ require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/tei'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::Tei
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Tei
 extend TrajectPlus::Macros::Xml
@@ -22,60 +26,64 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
 
-# Constants
-MS_CONTENTS = 'tei:msContents'
-MS_DESC = '/*/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'
-MS_ID = 'tei:msIdentifier'
-MS_ITEM = 'tei:msItem'
-MS_ORIGIN = 'tei:history/tei:origin'
-OBJ_DESC = 'tei:physDesc/tei:objectDesc'
-PROFILE_DESC = '/*/tei:teiHeader/tei:profileDesc/tei:textClass'
-PUB_STMT = '/*/tei:teiHeader/tei:fileDesc/tei:publicationStmt'
-SUPPORT_DESC = 'tei:supportDesc[@material="paper"]'
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
-# CHO Required
+# Cho Required
 to_field 'id', lambda { |_record, accumulator, context|
   bare_id = default_identifier(context)
   accumulator << identifier_with_prefix(context, bare_id)
 }
-to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[1]"), strip
-to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[@type='vernacular']"), strip, lang('ar-Arab')
 
-# CHO Other
-to_field 'cho_date', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origDate"), strip, lang('en')
-to_field 'cho_dc_rights', extract_tei("#{PUB_STMT}/tei:availability/tei:licence"), strip, lang('en')
-to_field 'cho_description', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:summary"), strip, lang('en')
-to_field 'cho_edm_type', literal('Text'), lang('en')
-to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
-to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/tei:layoutDesc/tei:layout")
-to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/#{SUPPORT_DESC}/tei:extent")
-to_field 'cho_has_type', literal('Manuscript'), lang('en')
-to_field 'cho_has_type', literal('Manuscript'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+PUB_STMT = '/*/tei:teiHeader/tei:fileDesc/tei:publicationStmt'
+to_field 'cho_publisher', extract_tei("#{PUB_STMT}/tei:publisher")
+to_field 'cho_dc_rights', extract_tei("#{PUB_STMT}/tei:availability/tei:licence"), strip
+
+MS_DESC = '/*/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'
+MS_ID = 'tei:msIdentifier'
 to_field 'cho_identifier', extract_tei("#{MS_DESC}/#{MS_ID}/tei:idno[@type='call-number']")
-to_field 'cho_language', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:textLang/@mainLang"), normalize_language, lang('en')
-to_field 'cho_language', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:textLang/@mainLang"), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
-to_field 'cho_provenance', extract_tei("#{MS_DESC}/tei:history/tei:provenance"), strip, lang('en')
-to_field 'cho_publisher', extract_tei("#{PUB_STMT}/tei:publisher"), strip, lang('en')
-to_field 'cho_spatial', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origPlace"), strip, lang('en')
-to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='form/genre']/tei:term"), strip, lang('en')
-to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='subjects']/tei:term"), strip, lang('en')
-
-# Agg
-to_field 'agg_data_provider', data_provider, lang('en')
-to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
-to_field 'agg_data_provider_country', data_provider_country, lang('en')
-to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
-to_field 'agg_edm_rights', public_domain
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context, 'wr_id' => [extract_tei("#{MS_DESC}/#{MS_ID}/tei:altIdentifier[@type='openn-url']/tei:idno")])
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context, 'wr_id' => [openn_thumbnail])
 end
+to_field 'cho_edm_type', literal('Text')
+
+MS_CONTENTS = 'tei:msContents'
+to_field 'cho_description', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:summary")
+to_field 'cho_language', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:textLang/@mainLang"), normalize_language
+
+MS_ITEM = 'tei:msItem'
+to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[1]")
+to_field 'cho_creator', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:author")
+
+MS_ORIGIN = 'tei:history/tei:origin'
+to_field 'cho_date', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origDate")
+to_field 'cho_spatial', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origPlace")
+to_field 'cho_provenance', extract_tei("#{MS_DESC}/tei:history/tei:provenance")
+
+OBJ_DESC = 'tei:physDesc/tei:objectDesc'
+to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/tei:layoutDesc/tei:layout")
+
+SUPPORT_DESC = 'tei:supportDesc[@material="paper"]'
+to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/#{SUPPORT_DESC}/tei:extent")
+
+PROFILE_DESC = '/*/tei:teiHeader/tei:profileDesc/tei:textClass'
+to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='form/genre']/tei:term")
+to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='subjects']/tei:term")
+
+# Provider fields [REQUIRED]
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_edm_rights', public_domain
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
 each_record convert_to_language_hash(
   'agg_data_provider',
@@ -85,6 +93,7 @@ each_record convert_to_language_hash(
   'cho_alternative',
   'cho_contributor',
   'cho_coverage',
+  'cho_creator',
   'cho_date',
   'cho_dc_rights',
   'cho_description',

--- a/traject_configs/openn_common_config.rb
+++ b/traject_configs/openn_common_config.rb
@@ -5,13 +5,13 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
-require 'macros/tei'
 require 'macros/timestamp'
 require 'macros/version'
+require 'macros/tei'
 require 'traject_plus'
 
-extend Macros::DLME
 extend Macros::DateParsing
+extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::Tei
@@ -30,60 +30,60 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
-# Cho Required
+# Constants
+MS_CONTENTS = 'tei:msContents'
+MS_DESC = '/*/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'
+MS_ID = 'tei:msIdentifier'
+MS_ITEM = 'tei:msItem'
+MS_ORIGIN = 'tei:history/tei:origin'
+OBJ_DESC = 'tei:physDesc/tei:objectDesc'
+PROFILE_DESC = '/*/tei:teiHeader/tei:profileDesc/tei:textClass'
+PUB_STMT = '/*/tei:teiHeader/tei:fileDesc/tei:publicationStmt'
+SUPPORT_DESC = 'tei:supportDesc[@material="paper"]'
+
+# CHO Required
 to_field 'id', lambda { |_record, accumulator, context|
   bare_id = default_identifier(context)
   accumulator << identifier_with_prefix(context, bare_id)
 }
+to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[1]"), strip
+to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[@type='vernacular']"), strip, lang('ar-Arab')
 
-PUB_STMT = '/*/tei:teiHeader/tei:fileDesc/tei:publicationStmt'
-to_field 'cho_publisher', extract_tei("#{PUB_STMT}/tei:publisher")
-to_field 'cho_dc_rights', extract_tei("#{PUB_STMT}/tei:availability/tei:licence"), strip
-
-MS_DESC = '/*/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'
-MS_ID = 'tei:msIdentifier'
+# CHO Other
+to_field 'cho_date', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origDate"), strip, lang('en')
+to_field 'cho_dc_rights', extract_tei("#{PUB_STMT}/tei:availability/tei:licence"), strip, lang('en')
+to_field 'cho_description', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:summary"), strip, lang('en')
+to_field 'cho_edm_type', literal('Text'), lang('en')
+to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
+to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/tei:layoutDesc/tei:layout")
+to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/#{SUPPORT_DESC}/tei:extent")
+to_field 'cho_has_type', literal('Manuscript'), lang('en')
+to_field 'cho_has_type', literal('Manuscript'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_tei("#{MS_DESC}/#{MS_ID}/tei:idno[@type='call-number']")
+to_field 'cho_language', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:textLang/@mainLang"), normalize_language, lang('en')
+to_field 'cho_language', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:textLang/@mainLang"), normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_provenance', extract_tei("#{MS_DESC}/tei:history/tei:provenance"), strip, lang('en')
+to_field 'cho_publisher', extract_tei("#{PUB_STMT}/tei:publisher"), strip, lang('en')
+to_field 'cho_spatial', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origPlace"), strip, lang('en')
+to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='form/genre']/tei:term"), strip, lang('en')
+to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='subjects']/tei:term"), strip, lang('en')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_edm_rights', public_domain
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context, 'wr_id' => [extract_tei("#{MS_DESC}/#{MS_ID}/tei:altIdentifier[@type='openn-url']/tei:idno")])
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context, 'wr_id' => [openn_thumbnail])
 end
-to_field 'cho_edm_type', literal('Text')
-
-MS_CONTENTS = 'tei:msContents'
-to_field 'cho_description', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:summary")
-to_field 'cho_language', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/tei:textLang/@mainLang"), normalize_language
-
-MS_ITEM = 'tei:msItem'
-to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[1]")
-to_field 'cho_creator', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:author")
-
-MS_ORIGIN = 'tei:history/tei:origin'
-to_field 'cho_date', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origDate")
-to_field 'cho_spatial', extract_tei("#{MS_DESC}/#{MS_ORIGIN}/tei:origPlace")
-to_field 'cho_provenance', extract_tei("#{MS_DESC}/tei:history/tei:provenance")
-
-OBJ_DESC = 'tei:physDesc/tei:objectDesc'
-to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/tei:layoutDesc/tei:layout")
-
-SUPPORT_DESC = 'tei:supportDesc[@material="paper"]'
-to_field 'cho_extent', extract_tei("#{MS_DESC}/#{OBJ_DESC}/#{SUPPORT_DESC}/tei:extent")
-
-PROFILE_DESC = '/*/tei:teiHeader/tei:profileDesc/tei:textClass'
-to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='form/genre']/tei:term")
-to_field 'cho_subject', extract_tei("#{PROFILE_DESC}/tei:keywords[@n='subjects']/tei:term")
-
-# Provider fields [REQUIRED]
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
-to_field 'agg_data_provider', data_provider, lang('en')
-to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
-to_field 'agg_edm_rights', public_domain
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
-to_field 'agg_data_provider_country', data_provider_country, lang('en')
-to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
 each_record convert_to_language_hash(
   'agg_data_provider',
@@ -93,7 +93,6 @@ each_record convert_to_language_hash(
   'cho_alternative',
   'cho_contributor',
   'cho_coverage',
-  'cho_creator',
   'cho_date',
   'cho_dc_rights',
   'cho_description',

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -6,16 +6,17 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_type'
+require 'macros/penn'
 require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Csv
 extend Macros::DLME
-extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
 extend Macros::NormalizeType
+extend Macros::Penn
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -32,42 +33,43 @@ to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', normalize_prefixed_id('emuIRN')
-to_field 'cho_title', column('object_name'), split('|')
+to_field 'cho_title', column('object_name'), split('|'), lang('en')
 
 # CHO Other
-to_field 'cho_coverage', column('culture'), split('|')
-to_field 'cho_creator', column('creator')
-to_field 'agg_data_provider', column('curatorial_section'), append(' Section, Penn Museum')
-to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
-to_field 'cho_date', column('date_made')
-to_field 'cho_date', column('date_made_early')
-to_field 'cho_date', column('date_made_late')
+to_field 'cho_coverage', column('culture'), split('|'), lang('en')
+to_field 'cho_creator', column('creator'), lang('en')
+to_field 'cho_date', column('date_made'), lang('en')
+to_field 'cho_date', column('date_made_early'), lang('en')
+to_field 'cho_date', column('date_made_late'), lang('en')
 to_field 'cho_date_range_norm', penn_museum_date_range
 to_field 'cho_date_range_hijri', penn_museum_date_range, hijri_range
-to_field 'cho_description', column('description')
-to_field 'cho_description', column('technique'), split('|')
-to_field 'cho_edm_type', literal('Image')
-to_field 'cho_extent', column('measurement_height')
-to_field 'cho_extent', column('measurement_length')
-to_field 'cho_extent', column('measurement_outside_diameter')
-to_field 'cho_extent', column('measurement_tickness')
-to_field 'cho_extent', column('measurement_unit')
-to_field 'cho_extent', column('measurement_width')
+to_field 'cho_description', column('description'), lang('en')
+to_field 'cho_description', column('technique'), split('|'), lang('en')
+to_field 'cho_edm_type', literal('Image'), lang('en')
+to_field 'cho_edm_type', literal('Image'), translation_map('norm_types_to_ar'), lang('ar-Arab')
+to_field 'cho_extent', column('measurement_height'), lang('en')
+to_field 'cho_extent', column('measurement_length'), lang('en')
+to_field 'cho_extent', column('measurement_outside_diameter'), lang('en')
+to_field 'cho_extent', column('measurement_tickness'), lang('en')
+to_field 'cho_extent', column('measurement_unit'), lang('en')
+to_field 'cho_extent', column('measurement_width'), lang('en')
+to_field 'cho_has_type', column('object_name'), penn_cho_has_type, lang('en')
+to_field 'cho_has_type', column('object_name'), penn_cho_has_type, translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', column('emuIRN')
-to_field 'cho_medium', column('material'), split('|')
-to_field 'cho_provenance', column('accession_credit_line')
-to_field 'cho_source', column('object_number')
-to_field 'cho_source', column('other_numbers'), split('|')
-to_field 'cho_spatial', column('provenience'), split('|')
-to_field 'cho_subject', column('iconography')
-to_field 'cho_temporal', column('period'), split('|')
-to_field 'cho_type', column('object_name')
+to_field 'cho_medium', column('material'), split('|'), lang('en')
+to_field 'cho_provenance', column('accession_credit_line'), lang('en')
+to_field 'cho_source', column('object_number'), lang('en')
+to_field 'cho_source', column('other_numbers'), split('|'), lang('en')
+to_field 'cho_spatial', column('provenience'), split('|'), lang('en')
+to_field 'cho_subject', column('iconography'), lang('en')
+to_field 'cho_temporal', column('period'), split('|'), lang('en')
+to_field 'cho_type', column('object_name'), lang('en')
 
 # Agg
-to_field 'agg_provider', provider, lang('en')
-to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_data_provider', data_provider, lang('en')
 to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('url')])
@@ -76,11 +78,10 @@ to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('thumbnail'), gsub('collections/assets/1600', 'collections/assets/300')])
 end
-
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
-to_field 'agg_data_provider_country', data_provider_country, lang('en')
-to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -6,15 +6,18 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_type'
-require 'macros/penn'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Csv
 extend Macros::DLME
+extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
 extend Macros::NormalizeType
-extend Macros::Penn
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 
@@ -23,45 +26,48 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
 end
 
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
 # CHO Required
 to_field 'id', normalize_prefixed_id('emuIRN')
-to_field 'cho_title', column('object_name'), split('|'), lang('en')
+to_field 'cho_title', column('object_name'), split('|')
 
 # CHO Other
-to_field 'cho_coverage', column('culture'), split('|'), lang('en')
-to_field 'cho_creator', column('creator'), lang('en')
-to_field 'cho_date', column('date_made'), lang('en')
-to_field 'cho_date', column('date_made_early'), lang('en')
-to_field 'cho_date', column('date_made_late'), lang('en')
+to_field 'cho_coverage', column('culture'), split('|')
+to_field 'cho_creator', column('creator')
+to_field 'agg_data_provider', column('curatorial_section'), append(' Section, Penn Museum')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'cho_date', column('date_made')
+to_field 'cho_date', column('date_made_early')
+to_field 'cho_date', column('date_made_late')
 to_field 'cho_date_range_norm', penn_museum_date_range
 to_field 'cho_date_range_hijri', penn_museum_date_range, hijri_range
-to_field 'cho_description', column('description'), lang('en')
-to_field 'cho_description', column('technique'), split('|'), lang('en')
-to_field 'cho_edm_type', literal('Image'), lang('en')
-to_field 'cho_edm_type', literal('Image'), translation_map('norm_types_to_ar'), lang('ar-Arab')
-to_field 'cho_extent', column('measurement_height'), lang('en')
-to_field 'cho_extent', column('measurement_length'), lang('en')
-to_field 'cho_extent', column('measurement_outside_diameter'), lang('en')
-to_field 'cho_extent', column('measurement_tickness'), lang('en')
-to_field 'cho_extent', column('measurement_unit'), lang('en')
-to_field 'cho_extent', column('measurement_width'), lang('en')
-to_field 'cho_has_type', column('object_name'), penn_cho_has_type, lang('en')
-to_field 'cho_has_type', column('object_name'), penn_cho_has_type, translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_description', column('description')
+to_field 'cho_description', column('technique'), split('|')
+to_field 'cho_edm_type', literal('Image')
+to_field 'cho_extent', column('measurement_height')
+to_field 'cho_extent', column('measurement_length')
+to_field 'cho_extent', column('measurement_outside_diameter')
+to_field 'cho_extent', column('measurement_tickness')
+to_field 'cho_extent', column('measurement_unit')
+to_field 'cho_extent', column('measurement_width')
 to_field 'cho_identifier', column('emuIRN')
-to_field 'cho_medium', column('material'), split('|'), lang('en')
-to_field 'cho_provenance', column('accession_credit_line'), lang('en')
-to_field 'cho_source', column('object_number'), lang('en')
-to_field 'cho_source', column('other_numbers'), split('|'), lang('en')
-to_field 'cho_spatial', column('provenience'), split('|'), lang('en')
-to_field 'cho_subject', column('iconography'), lang('en')
-to_field 'cho_temporal', column('period'), split('|'), lang('en')
-to_field 'cho_type', column('object_name'), lang('en')
+to_field 'cho_medium', column('material'), split('|')
+to_field 'cho_provenance', column('accession_credit_line')
+to_field 'cho_source', column('object_number')
+to_field 'cho_source', column('other_numbers'), split('|')
+to_field 'cho_spatial', column('provenience'), split('|')
+to_field 'cho_subject', column('iconography')
+to_field 'cho_temporal', column('period'), split('|')
+to_field 'cho_type', column('object_name')
 
 # Agg
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_data_provider', data_provider, lang('en')
 to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
-to_field 'agg_data_provider_country', data_provider_country, lang('en')
-to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('url')])
@@ -70,10 +76,11 @@ to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('thumbnail'), gsub('collections/assets/1600', 'collections/assets/300')])
 end
-to_field 'agg_provider', provider, lang('en')
-to_field 'agg_provider', provider_ar, lang('ar-Arab')
+
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/pppa_config.rb
+++ b/traject_configs/pppa_config.rb
@@ -5,12 +5,16 @@ require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Csv
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 
@@ -18,6 +22,10 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', column('Resource_URL')

--- a/traject_configs/princeton_movie_config.rb
+++ b/traject_configs/princeton_movie_config.rb
@@ -4,11 +4,15 @@ require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -16,6 +20,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_json('.identifier'), strip

--- a/traject_configs/princeton_mss_config.rb
+++ b/traject_configs/princeton_mss_config.rb
@@ -4,11 +4,15 @@ require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -16,6 +20,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_json('.identifier'), strip

--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -5,11 +5,15 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/qnl'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend Macros::QNL
 extend TrajectPlus::Macros
 
@@ -17,6 +21,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO Required
 to_field 'id', extract_qnl_identifier, strip

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -8,6 +8,8 @@ require 'macros/each_record'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/oai'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::ContentDm
@@ -17,12 +19,18 @@ extend Macros::EachRecord
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
 extend Macros::OAI
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 
 settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_oai_identifier, strip

--- a/traject_configs/yale_medical_config.rb
+++ b/traject_configs/yale_medical_config.rb
@@ -4,11 +4,15 @@ require 'dlme_json_resource_writer'
 require 'macros/csv'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/timestamp'
+require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Csv
 extend Macros::DLME
 extend Macros::EachRecord
+extend Macros::Timestamp
+extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 
@@ -16,6 +20,10 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
 end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
 
 # CHO required
 to_field 'id', normalize_prefixed_id('OrbisBibID'), strip


### PR DESCRIPTION
## Why was this change made?

In order to identify issues between transformation, indexing, and displaying, it will be very helpful to have a version tag and timestamp in the IR output.

This adds values like:

```
"transform_version":"ea0293c",
"transform_timestamp":"2019-11-20 10:47:07 -0800"
```

## Was the documentation (README, API, wiki, ...) updated?

N/A