### PR TITLE
Do not add empty strings to language hashed values

### DIFF
--- a/lib/contracts/cho.rb
+++ b/lib/contracts/cho.rb
@@ -73,7 +73,7 @@ module Contracts
     # rubocop:disable Metrics/AbcSize
     def self.required_language_specific_rule
       proc do
-        key.failure('no values provided') if value.keys.empty?
+        key.failure('no values provided') if value.keys.empty? || value.values&.first&.empty?
         unexpected_keys = value.keys - expected_language_values
         key.failure("unexpected language code(s) found in #{key.path.keys.first}: #{unexpected_keys.join(', ')}") if
           unexpected_keys.any?

--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'byebug'
-
 module Macros
   # Macros for post-processing data
   module EachRecord
@@ -18,7 +16,6 @@ module Macros
           values.each do |value|
             case value
             when Hash
-              # byebug
               result[value[:language]] += value[:values].reject(&:nil?).reject(&:empty?)
             else
               result['none'] += Array(value)

--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'byebug'
+
 module Macros
   # Macros for post-processing data
   module EachRecord
@@ -16,7 +18,8 @@ module Macros
           values.each do |value|
             case value
             when Hash
-              result[value[:language]] += value[:values]
+              # byebug
+              result[value[:language]] += value[:values].reject(&:nil?).reject(&:empty?)
             else
               result['none'] += Array(value)
             end

--- a/spec/lib/traject/macros/each_record_spec.rb
+++ b/spec/lib/traject/macros/each_record_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe Macros::EachRecord do
         expect(mock_context.output_hash).to eq('cho_title' => { 'en' => ['title1'] })
       end
     end
+
+    context 'when output hash has empty values for given fields' do
+      let(:output_hash) { { 'cho_title' => [] } }
+
+      it 'does not accumulate values in the hash' do
+        macro.call(nil, mock_context)
+        expect(mock_context.output_hash).to eq('cho_title' => {})
+      end
+    end
   end
 
   describe '#add_cho_type_facet' do


### PR DESCRIPTION
## Why was this change made?

Fixes #413 

If the first value in the language hash is empty, raise an error.

## Was the documentation (README, API, wiki, ...) updated?

N/A