### PR TITLE
Move the git call in ENV.fetch to a block call

### DIFF
--- a/lib/macros/version.rb
+++ b/lib/macros/version.rb
@@ -8,7 +8,7 @@ module Macros
     # @return [Proc] a proc that traject can call for each record
     def version
       lambda do |_, accumulator|
-        accumulator << ENV.fetch('VERSION', `git rev-parse --short HEAD`.strip)
+        accumulator << ENV.fetch('VERSION') { `git rev-parse --short HEAD`.strip }
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #419 

This avoids raising an error in docker when git is not installed.

## Was the documentation (README, API, wiki, ...) updated?
