### PR TITLE
Add a debug writer to allow local debugging

### DIFF
--- a/lib/dlme_debug_writer.rb
+++ b/lib/dlme_debug_writer.rb
@@ -2,23 +2,22 @@
 
 require 'adjust_cardinality'
 require 'contracts'
-require 'dlme_utils'
 
 # Write the traject output to newline delmitited json
 # This writer also casts fields that should be singular (like `id`) from lists.
 # Finally, it runs the DLME IR schema validator on each output to ensure the config
 # is writing a compliant message.
-class DlmeJsonResourceWriter < Traject::LineWriter
+class DlmeDebugWriter < Traject::LineWriter
   def serialize(context)
     attributes = context.output_hash.dup
     adjusted = AdjustCardinality.call(attributes)
     errors = validate(adjusted)
     return JSON.generate(adjusted).unicode_normalize if errors.empty?
 
-    ::DLME::Utils.logger.error "Transform produced invalid data.\n\n" \
+    raise "Transform produced invalid data.\n\n" \
       "The errors are: #{errors.messages}}\n\n" \
       "The data looked like this:\n" \
-      "The record id is: #{adjusted['id']}"
+      "#{JSON.pretty_generate(adjusted)}"
   end
 
   private

--- a/lib/transformer.rb
+++ b/lib/transformer.rb
@@ -33,7 +33,7 @@ module Dlme
         indexer.settings do
           provide 'command_line.filename', this.input_filepath
           provide 'close_output_on_close', false
-          store 'writer_class_name', 'Traject::DebugWriter' if this.debug_writer
+          store 'writer_class_name', 'DlmeDebugWriter' if this.debug_writer
           this.addl_settings.each { |key, value| provide key, value }
         end
       end

--- a/spec/lib/dlme_debug_writer_spec.rb
+++ b/spec/lib/dlme_debug_writer_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'stringio'
-require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 
-RSpec.describe DlmeJsonResourceWriter do
+RSpec.describe DlmeDebugWriter do
   let(:out) { StringIO.new }
   let(:settings) { { 'output_stream' => out } }
   let(:context) do
@@ -28,9 +28,9 @@ RSpec.describe DlmeJsonResourceWriter do
         { 'id' => ['one'], 'two' => %w[two1 two2], 'three' => 'three', 'four' => 'four' }
       end
       it 'logs an error' do
-        allow(::DLME::Utils.logger).to receive(:error)
-        put
-        expect(::DLME::Utils.logger).to have_received(:error)
+        expect { put }.to raise_error(
+          /Transform produced invalid data.\n\nThe errors are: .*"is missing".*/
+        )
       end
     end
   end

--- a/spec/lib/dlme_debug_writer_spec.rb
+++ b/spec/lib/dlme_debug_writer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DlmeDebugWriter do
       let(:data) do
         { 'id' => ['one'], 'two' => %w[two1 two2], 'three' => 'three', 'four' => 'four' }
       end
-      it 'logs an error' do
+      it 'raises an error' do
         expect { put }.to raise_error(
           /Transform produced invalid data.\n\nThe errors are: .*"is missing".*/
         )

--- a/spec/lib/transformer_spec.rb
+++ b/spec/lib/transformer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dlme::Transformer do
       let(:debug_writer) { true }
 
       it 'correctly configures indexer' do
-        expect(indexer.settings).to include('writer_class_name' => 'Traject::DebugWriter')
+        expect(indexer.settings).to include('writer_class_name' => 'DlmeDebugWriter')
       end
     end
 

--- a/traject_configs/aims_config.rb
+++ b/traject_configs/aims_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/aims'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/auc_al_musawwar_coll29_config.rb
+++ b/traject_configs/auc_al_musawwar_coll29_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_alexandria_bombardment_coll9_config.rb
+++ b/traject_configs/auc_alexandria_bombardment_coll9_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_bint_alnil_coll19_config.rb
+++ b/traject_configs/auc_bint_alnil_coll19_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_campus_photos_coll32_config.rb
+++ b/traject_configs/auc_campus_photos_coll32_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_coptic_coll4_config.rb
+++ b/traject_configs/auc_coptic_coll4_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_creswell_coll14_config.rb
+++ b/traject_configs/auc_creswell_coll14_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_fathy_coll13_config.rb
+++ b/traject_configs/auc_fathy_coll13_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_historical_videos_coll23_config.rb
+++ b/traject_configs/auc_historical_videos_coll23_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_hopkins_coll12_config.rb
+++ b/traject_configs/auc_hopkins_coll12_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_islamic_aa_coll30_config.rb
+++ b/traject_configs/auc_islamic_aa_coll30_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_kraus_meyerhof_coll1_config.rb
+++ b/traject_configs/auc_kraus_meyerhof_coll1_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_maps_coll6_config.rb
+++ b/traject_configs/auc_maps_coll6_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_maritz_coll16_config.rb
+++ b/traject_configs/auc_maritz_coll16_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_napoleonic_egypt_coll2_config.rb
+++ b/traject_configs/auc_napoleonic_egypt_coll2_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_parker_coll31_config.rb
+++ b/traject_configs/auc_parker_coll31_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_postcards_coll21_config.rb
+++ b/traject_configs/auc_postcards_coll21_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_qurna_coll24_config.rb
+++ b/traject_configs/auc_qurna_coll24_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_rare_books_coll11_config.rb
+++ b/traject_configs/auc_rare_books_coll11_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_student_news_coll26_config.rb
+++ b/traject_configs/auc_student_news_coll26_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_taxiphote_slides_coll15_config.rb
+++ b/traject_configs/auc_taxiphote_slides_coll15_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_underwood_coll8_config.rb
+++ b/traject_configs/auc_underwood_coll8_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/auc_wassef_coll5_config.rb
+++ b/traject_configs/auc_wassef_coll5_config.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/bnf_common_config.rb
+++ b/traject_configs/bnf_common_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
+require 'dlme_debug_writer'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -2,6 +2,7 @@
 
 require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/cambridge_config.rb
+++ b/traject_configs/cambridge_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/cluster_config.rb
+++ b/traject_configs/cluster_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
+require 'dlme_debug_writer'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/timestamp'

--- a/traject_configs/csv_config.rb
+++ b/traject_configs/csv_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/csv'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/fgdc_config.rb
+++ b/traject_configs/fgdc_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/harvard_ihp_config.rb
+++ b/traject_configs/harvard_ihp_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/iiif_config.rb
+++ b/traject_configs/iiif_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/timestamp'

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'

--- a/traject_configs/met_config.rb
+++ b/traject_configs/met_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/michigan_config.rb
+++ b/traject_configs/michigan_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'

--- a/traject_configs/michigan_old_config.rb
+++ b/traject_configs/michigan_old_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/mods_config.rb
+++ b/traject_configs/mods_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/openn_common_config.rb
+++ b/traject_configs/openn_common_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/pppa_config.rb
+++ b/traject_configs/pppa_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/princeton_islamic_mss_config.rb
+++ b/traject_configs/princeton_islamic_mss_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/princeton_movie_config.rb
+++ b/traject_configs/princeton_movie_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/princeton_mss_common_config.rb
+++ b/traject_configs/princeton_mss_common_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/princeton_mss_config.rb
+++ b/traject_configs/princeton_mss_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'

--- a/traject_configs/yale_medical_config.rb
+++ b/traject_configs/yale_medical_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
 require 'macros/csv'
 require 'macros/dlme'
 require 'macros/each_record'


### PR DESCRIPTION
## Why was this change made?

This adds a debug writer that can be used with the `-w` command line option. We currently fail in the out-of-the-box traject debug writer as our `serialize` method has been significantly customized.

This removes raising an error the DlmeJsonResourceWriter so that large collections do not fail on single records, but allows local development to utilize the `-w` option to fail on single records for debugging.

Bonus outcome is that this should fix the flappy integration test that is based on pulling `dlme-metadata`.

## Was the documentation (README, API, wiki, ...) updated?

TBD: A small update to the README may be required.