### PR TITLE
Add collection value as agg_data_provider_collection to IR

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,7 @@ fields:
       - agg_preview
       - transform_version
       - transform_timestamp
+      - agg_data_provider_collection
     web_resources:
       - agg_is_shown_at
       - agg_is_shown_by

--- a/lib/contracts/cho.rb
+++ b/lib/contracts/cho.rb
@@ -41,6 +41,7 @@ module Contracts
       required(:id).filled(:string)
       optional('__source'.to_sym).filled(:string)
       # Since the IR is a flattened projection of the MAP, 'agg_aggregated_cho' is not used.
+      required(:agg_data_provider_collection).value(:string)
       required(:agg_data_provider).value(:hash?)
       required(:agg_data_provider_country).value(:hash?)
       optional(:agg_dc_rights).array(:str?)

--- a/lib/macros/collection.rb
+++ b/lib/macros/collection.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module Macros
+  # Macro for setting the collection of the current data file
+  module Collection
+    # Drops the first default_data_path and the file from the pathname as collection
+    # @return [Proc] a proc that traject can call for each record
+    def collection
+      lambda do |_, accumulator, context|
+        accumulator << File.join(Pathname(context.input_name).each_filename.to_a[1...-1])
+      end
+    end
+  end
+end

--- a/spec/lib/traject/macros/collection.rb
+++ b/spec/lib/traject/macros/collection.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'macros/collection'
+
+RSpec.describe Macros::Collection do
+  let(:klass) do
+    Class.new do
+      include Macros::Collection
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe '#collection' do
+    let(:collection) { 'stanford/maps' }
+    let(:input_name) { 'data/stanford/maps/file_1.xml' }
+    it 'returns a path string that cooresponds to a collection' do
+      context = {}
+      allow(context).to receive(:input_name).and_return(input_name)
+      callable = instance.collection
+      expect(callable.call(nil, [], context)).to eq([collection])
+    end
+  end
+end

--- a/traject_configs/aims_config.rb
+++ b/traject_configs/aims_config.rb
@@ -3,6 +3,7 @@
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
 require 'macros/aims'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -10,6 +11,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::AIMS
 extend Macros::DLME
 extend Macros::DateParsing
@@ -22,6 +24,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -26,6 +28,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_al_musawwar_coll29_config.rb
+++ b/traject_configs/auc_al_musawwar_coll29_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_alexandria_bombardment_coll9_config.rb
+++ b/traject_configs/auc_alexandria_bombardment_coll9_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_bint_alnil_coll19_config.rb
+++ b/traject_configs/auc_bint_alnil_coll19_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_campus_photos_coll32_config.rb
+++ b/traject_configs/auc_campus_photos_coll32_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -26,6 +28,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_coptic_coll4_config.rb
+++ b/traject_configs/auc_coptic_coll4_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_creswell_coll14_config.rb
+++ b/traject_configs/auc_creswell_coll14_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_fathy_coll13_config.rb
+++ b/traject_configs/auc_fathy_coll13_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -26,6 +28,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_historical_videos_coll23_config.rb
+++ b/traject_configs/auc_historical_videos_coll23_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_hopkins_coll12_config.rb
+++ b/traject_configs/auc_hopkins_coll12_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_islamic_aa_coll30_config.rb
+++ b/traject_configs/auc_islamic_aa_coll30_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -26,6 +28,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_kraus_meyerhof_coll1_config.rb
+++ b/traject_configs/auc_kraus_meyerhof_coll1_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_maps_coll6_config.rb
+++ b/traject_configs/auc_maps_coll6_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_maritz_coll16_config.rb
+++ b/traject_configs/auc_maritz_coll16_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_napoleonic_egypt_coll2_config.rb
+++ b/traject_configs/auc_napoleonic_egypt_coll2_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_parker_coll31_config.rb
+++ b/traject_configs/auc_parker_coll31_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_postcards_coll21_config.rb
+++ b/traject_configs/auc_postcards_coll21_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_qurna_coll24_config.rb
+++ b/traject_configs/auc_qurna_coll24_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_rare_books_coll11_config.rb
+++ b/traject_configs/auc_rare_books_coll11_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_student_news_coll26_config.rb
+++ b/traject_configs/auc_student_news_coll26_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_taxiphote_slides_coll15_config.rb
+++ b/traject_configs/auc_taxiphote_slides_coll15_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_underwood_coll8_config.rb
+++ b/traject_configs/auc_underwood_coll8_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -14,6 +15,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -30,6 +32,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/auc_wassef_coll5_config.rb
+++ b/traject_configs/auc_wassef_coll5_config.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/string/inflections'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/bnf_common_config.rb
+++ b/traject_configs/bnf_common_config.rb
@@ -3,6 +3,7 @@
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -26,6 +28,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/bodleian_config.rb
+++ b/traject_configs/bodleian_config.rb
@@ -3,6 +3,7 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -10,6 +11,7 @@ require 'macros/normalize_language'
 require 'macros/timestamp'
 require 'macros/version'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -23,6 +25,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/cambridge_config.rb
+++ b/traject_configs/cambridge_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -11,6 +12,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -26,6 +28,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/cluster_config.rb
+++ b/traject_configs/cluster_config.rb
@@ -3,12 +3,14 @@
 require 'dlme_json_resource_writer'
 require 'macros/date_parsing'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -21,6 +23,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/csv_config.rb
+++ b/traject_configs/csv_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/csv'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -9,6 +10,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::Csv
 extend Macros::DLME
 extend Macros::EachRecord
@@ -19,6 +21,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/fgdc_config.rb
+++ b/traject_configs/fgdc_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -10,6 +11,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -24,6 +26,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/harvard_ihp_config.rb
+++ b/traject_configs/harvard_ihp_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -27,6 +29,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/iiif_config.rb
+++ b/traject_configs/iiif_config.rb
@@ -2,12 +2,14 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::Timestamp
@@ -18,6 +20,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/marc_config.rb
+++ b/traject_configs/marc_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
@@ -13,6 +14,7 @@ require 'traject/macros/marc21_semantics'
 require 'traject/macros/marc_format_classifier'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::DlmeMarc
@@ -33,6 +35,8 @@ settings do
   # provide "reader_class_name", "MarcReader"
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/met_config.rb
+++ b/traject_configs/met_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -10,6 +11,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -25,6 +27,8 @@ settings do
 end
 
 # Note: Met JSON uses blanks ("") instead of nulls.
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/michigan_config.rb
+++ b/traject_configs/michigan_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
@@ -10,6 +11,7 @@ require 'traject/macros/marc21_semantics'
 require 'traject/macros/marc_format_classifier'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::DlmeMarc
@@ -25,6 +27,12 @@ settings do
   provide 'reader_class_name', 'MARC::XMLReader'
   provide 'marc_source.type', 'xml'
 end
+
+to_field 'agg_data_provider_collection', collection
+
+# # Set Version & Timestamp on each record
+# to_field 'transform_version', version
+# to_field 'transform_timestamp', timestamp
 
 # Cho Additional
 to_field 'cho_dc_rights', literal('Public Domain'), lang('en')

--- a/traject_configs/michigan_old_config.rb
+++ b/traject_configs/michigan_old_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -9,6 +10,7 @@ require 'macros/michigan'
 require 'macros/oai'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -21,6 +23,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Cho Required
 to_field 'id', extract_xpath("//controlfield[@tag='001']"), strip

--- a/traject_configs/mods_config.rb
+++ b/traject_configs/mods_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -29,6 +31,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -11,6 +12,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::Csv
 extend Macros::DLME
 extend Macros::DateParsing
@@ -25,6 +27,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/openn_common_config.rb
+++ b/traject_configs/openn_common_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -11,6 +12,7 @@ require 'macros/version'
 require 'macros/tei'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -26,6 +28,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/penn_museum_config.rb
+++ b/traject_configs/penn_museum_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -12,6 +13,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::Csv
 extend Macros::DLME
 extend Macros::DateParsing
@@ -27,6 +29,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/pppa_config.rb
+++ b/traject_configs/pppa_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -10,6 +11,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::Csv
 extend Macros::DateParsing
 extend Macros::DLME
@@ -23,6 +25,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/princeton_islamic_mss_config.rb
+++ b/traject_configs/princeton_islamic_mss_config.rb
@@ -2,16 +2,20 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
+
+to_field 'agg_data_provider_collection', collection
 
 # Cho Other
 to_field 'cho_contributor', extract_json('.contributor'), strip

--- a/traject_configs/princeton_movie_config.rb
+++ b/traject_configs/princeton_movie_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -9,6 +10,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -21,6 +23,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/princeton_mss_common_config.rb
+++ b/traject_configs/princeton_mss_common_config.rb
@@ -2,11 +2,13 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
@@ -17,6 +19,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Cho Required
 to_field 'id', extract_json('.identifier')

--- a/traject_configs/princeton_mss_config.rb
+++ b/traject_configs/princeton_mss_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -9,6 +10,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -21,6 +23,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -10,6 +11,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -22,6 +24,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/content_dm'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::ContentDm
 extend Macros::DateParsing
 extend Macros::DLME
@@ -28,6 +30,8 @@ settings do
   provide 'reader_class_name', 'TrajectPlus::XmlReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version

--- a/traject_configs/yale_medical_config.rb
+++ b/traject_configs/yale_medical_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
 require 'macros/csv'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -9,6 +10,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::Csv
 extend Macros::DLME
 extend Macros::EachRecord
@@ -21,6 +23,8 @@ settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
   provide 'reader_class_name', 'TrajectPlus::CsvReader'
 end
+
+to_field 'agg_data_provider_collection', collection
 
 # Set Version & Timestamp on each record
 to_field 'transform_version', version


### PR DESCRIPTION
## Why was this change made?

Extract the collection name from the input file path. All file paths start with the `data_path` (usually `./data/`) so that is dropped as well as dropping the individual input file name as we want the path as a collection, not the individual file as a collection.

This adds:
- agg_data_provider_collection to the contract
- a macro to extract the collection name as the path
- a test for the macro
- appropriate config and `to_field` to each traject config

Note, this is perhaps a intermediate way to set a usable collection value in order to extrapolate the number of collections per provider in the spotlight stats. A future update may be necessary to implement a lookup to a displayable collection value, but this is the MVP for providing the statistic value in the app.



