### PR TITLE
Return nil when a an error is logged in the resource writer

### DIFF
--- a/lib/dlme_json_resource_writer.rb
+++ b/lib/dlme_json_resource_writer.rb
@@ -19,6 +19,8 @@ class DlmeJsonResourceWriter < Traject::LineWriter
       "The errors are: #{errors.messages}}\n\n" \
       "The data looked like this:\n" \
       "The record id is: #{adjusted['id']}"
+
+    nil
   end
 
   private


### PR DESCRIPTION
## Why was this change made?

The default return inserted the value `true` into the json output when an error is logged. Which causes an error on item ingest.

## Was the documentation (README, API, wiki, ...) updated?

N/A