### PR TITLE
Add formatted iiif manifest to ans based on URL

### DIFF
--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -71,7 +71,8 @@ to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context,
-                                  'wr_id' => [column('URI')])
+                                  'wr_id' => [column('URI')],
+                                  'wr_is_referenced_by' => [column('URI'), gsub(/collection/, 'search/manifest')])
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,


### PR DESCRIPTION
## Why was this change made?

The links to the ANS items include a manifest by switching "collection" to "search/manifest".

