### PR TITLE
Add formatted iiif manifest to cambridge based on ID

### DIFF
--- a/lib/macros/cambridge.rb
+++ b/lib/macros/cambridge.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Macros
+  # Macros for extracting Stanford Specific MODS values from Nokogiri documents
+  module Cambridge
+    # Namespaces and prefixes for XML documents from Stanford
+    NS = { tei: 'http://www.tei-c.org/ns/1.0' }.freeze
+
+    # This is a ID for the Digital Object in its information context
+    # @param [Nokogiri::Document] record
+    # @return [String] the ID
+    def extract_record_id(record)
+      url = record.xpath('//tei:facsimile/tei:graphic/@url', NS).map(&:text).first
+      url.gsub!('http://cudl.lib.cam.ac.uk/content/images/', '')
+      url.gsub!('-000-00001_files/8/0_0.jpg', '')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Extract the ID from the URL, use the id to format the link and the iiif manifest URL.
