### PR TITLE
Test Turkish subtypes

### DIFF
--- a/lib/translation_maps/turkish_has_type_to_en.yaml
+++ b/lib/translation_maps/turkish_has_type_to_en.yaml
@@ -1,0 +1,25 @@
+# Turkish language types
+baskı: Book
+belge: Book
+broşür: broşür
+davetiye: davetiye
+desen: desen
+dijital fotoğraf: Photograph
+elyazma kitap: Manuscript
+fotoğraf: Photograph
+gotoğraf: Photograph
+gazete küpürü: Serial
+gravür: gravür
+hat: hat
+karikatür: karikatür
+kartpostal: Postcard
+kitap bölümü: Book
+kumaş: kumaş
+köşe yazısı: köşe yazısı
+makale: Serial
+mektup: mektup
+metin: metin
+resim: resim
+yazı: Serial
+yazı malzemeleri: yazı malzemeleri
+yazışma: yazışma

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -53,12 +53,12 @@ to_field 'cho_dc_rights', extract_oai('dc:rights'), strip, lang('tr-Latn')
 to_field 'cho_edm_type', extract_oai('dc:type'),
          strip, normalize_type, lang('en')
 to_field 'cho_edm_type', extract_oai('dc:type'),
-                  strip, normalize_type, translation_map('norm_types_to_ar'), lang('ar-Arab')
+         strip, normalize_type, translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_format', extract_oai('dc:format'), strip, lang('tr-Latn')
 to_field 'cho_has_type', extract_oai('dc:type'),
          strip, transform(&:downcase), translation_map('turkish_has_type_to_en'), lang('en')
 to_field 'cho_has_type', extract_oai('dc:type'),
-                  strip, transform(&:downcase), translation_map('turkish_has_type_to_en'), translation_map('norm_types_to_ar'), lang('ar-Arab')
+         strip, transform(&:downcase), translation_map('turkish_has_type_to_en'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_language', extract_oai('dc:language'), split(';'),
          strip, normalize_language, lang('en')
 to_field 'cho_publisher', extract_oai('dc:publisher'), strip, lang('tr-Latn')

--- a/traject_configs/sakip_sabanci_common_config.rb
+++ b/traject_configs/sakip_sabanci_common_config.rb
@@ -51,8 +51,14 @@ to_field 'cho_date', extract_oai('dc:date'), strip, lang('tr-Latn')
 to_field 'cho_description', extract_oai('dc:description'), strip, lang('tr-Latn')
 to_field 'cho_dc_rights', extract_oai('dc:rights'), strip, lang('tr-Latn')
 to_field 'cho_edm_type', extract_oai('dc:type'),
-         strip, normalize_type, lang('tr-Latn')
+         strip, normalize_type, lang('en')
+to_field 'cho_edm_type', extract_oai('dc:type'),
+                  strip, normalize_type, translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_format', extract_oai('dc:format'), strip, lang('tr-Latn')
+to_field 'cho_has_type', extract_oai('dc:type'),
+         strip, transform(&:downcase), translation_map('turkish_has_type_to_en'), lang('en')
+to_field 'cho_has_type', extract_oai('dc:type'),
+                  strip, transform(&:downcase), translation_map('turkish_has_type_to_en'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_language', extract_oai('dc:language'), split(';'),
          strip, normalize_language, lang('en')
 to_field 'cho_publisher', extract_oai('dc:publisher'), strip, lang('tr-Latn')


### PR DESCRIPTION
## Why was this change made?
There are many Turkish values in the type field that need to be mapped to subtypes (cho_has_type). It is unclear what some of the values mean so I mapped some and passed others through to view them in the application and determine if a new sub type label should be added. 

## Was the documentation (README, API, wiki, ...) updated?
n/a