### PR TITLE
Remove invalid iiif manifest urls from American Numismatic Society, closes https://github.com/sul-dlss/dlme/issues/795

### DIFF
--- a/traject_configs/numismatic_csv_config.rb
+++ b/traject_configs/numismatic_csv_config.rb
@@ -71,8 +71,7 @@ to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context,
-                                  'wr_id' => [column('URI')],
-                                  'wr_is_referenced_by' => [column('URI'), gsub(/collection/, 'search/manifest')])
+                                  'wr_id' => [column('URI')])
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,


### PR DESCRIPTION
## Why was this change made?

The iiif manifests were invalid and needed to be removed

## Was the documentation (README, API, wiki, ...) updated?

n/a