### PR TITLE
Add language to id

### DIFF
--- a/traject_configs/shahre_farang_arabic_config.rb
+++ b/traject_configs/shahre_farang_arabic_config.rb
@@ -31,7 +31,7 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # Cho Required
-to_field 'id', extract_json('.id'), strip
+to_field 'id', extract_json('.id'), strip, append('ar')
 to_field 'cho_title', extract_json('.title'), strip, lang('ar-Arab')
 
 # Cho Other

--- a/traject_configs/shahre_farang_english_config.rb
+++ b/traject_configs/shahre_farang_english_config.rb
@@ -31,7 +31,7 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # Cho Required
-to_field 'id', extract_json('.id'), strip
+to_field 'id', extract_json('.id'), strip, append('en')
 to_field 'cho_title', extract_json('.title'), strip, lang('en')
 
 # Cho Other

--- a/traject_configs/shahre_farang_persian_config.rb
+++ b/traject_configs/shahre_farang_persian_config.rb
@@ -31,7 +31,7 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # Cho Required
-to_field 'id', extract_json('.id'), strip
+to_field 'id', extract_json('.id'), strip, append('fa')
 to_field 'cho_title', extract_json('.title'), strip, lang('fa-Arab')
 
 # Cho Other


### PR DESCRIPTION
## Why was this change made?

Some of the records have versions in multiple languages (e.g. a version in Persian and in English). The ids for the two are sometimes the same but we want to include both because there are differences at times in the metadata and the descriptive text. 

## Was the documentation (README, API, wiki, ...) updated?

-n/a