### PR TITLE
Add a default override macro that works

### DIFF
--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -122,5 +122,13 @@ module Macros
         acc.last
       end
     end
+
+    # Override the traject default as our hashing clobbers the default method passing an empty array afterwards
+    # this is fixed by using the .replace method instead of appending.
+    def default(default_value)
+      lambda do |_rec, acc|
+        acc.replace([default_value]) if acc.reject { |_, v| v.nil? || v.empty? }.empty?
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

The upstream `default` method is problematic as it appends a value to the array and doesn't replace an empty array with the default. This causes issues with our hashed language structure.

## Was the documentation (README, API, wiki, ...) updated?
