### PR TITLE
update iiif manifests in LOC mapping

### DIFF
--- a/traject_configs/loc_abdul_hamid_ii_books_config.rb
+++ b/traject_configs/loc_abdul_hamid_ii_books_config.rb
@@ -67,8 +67,7 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.id'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('/manifest.json')]
+    'wr_id' => [extract_json('.id'), strip]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|

--- a/traject_configs/loc_greek_and_armenian_patriarchates_config.rb
+++ b/traject_configs/loc_greek_and_armenian_patriarchates_config.rb
@@ -65,7 +65,7 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.id'), strip],
-    'wr_is_referenced_by' => [extract_json('.url'), strip, append('/manifest.json')]
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('/manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|

--- a/traject_configs/loc_persian_config.rb
+++ b/traject_configs/loc_persian_config.rb
@@ -67,8 +67,8 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.segments[0].url'), strip],
-    'wr_is_referenced_by' => [extract_json('.number_lccn[0]'), strip, prepend('https://www.loc.gov/item/'), append('/manifest.json')]
+    'wr_id' => [extract_json('.id'), strip],
+    'wr_is_referenced_by' => [extract_json('id'), strip, append('/manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|


### PR DESCRIPTION
## Why was this change made?

- Some iiif manifests didn't have canvases and needed to be removed
- Better approach for grabbing iiif manifests with canvases

## Was the documentation (README, API, wiki, ...) updated?

n/a