### PR TITLE
Add English source YML for Transifex workflow

### DIFF
--- a/lib/translation_maps/norm_has_type_to_en.yaml
+++ b/lib/translation_maps/norm_has_type_to_en.yaml
@@ -1,0 +1,22 @@
+Book: Book
+Calligraphy: Calligraphy
+Cultural Artifact: Cultural Artifact
+Drawing: Drawing
+Interview: Interview
+Letter: Letter
+Manuscript: Manuscript
+Map: Map
+Motion Picture: Motion Picture
+Music: Music
+Newspaper: Newspaper
+Oral Narrative: Oral Narrative
+Other Document: Other Document
+Painting: Painting
+Periodical: Periodical
+Photograph: Photograph
+Postcard: Postcard
+Poster: Poster
+Radio Broadcast: Radio Broadcast
+Reference Book: Reference Book
+Sound Recording: Sound Recording
+Visual Art: Visual Art

--- a/lib/translation_maps/norm_languages_to_en.yaml
+++ b/lib/translation_maps/norm_languages_to_en.yaml
@@ -1,0 +1,44 @@
+Amharic: Amharic
+Ancient Greek (to 1453): Ancient Greek (to 1453)
+Arabic: Arabic
+Aramaic: Aramaic
+Armenian: Armenian
+Berber languages: Berber languages
+Catalan: Catalan
+Classical Syriac: Classical Syriac
+Coptic: Coptic
+Dutch; Flemish: Dutch; Flemish
+Egyptian (Ancient): Egyptian (Ancient)
+English: English
+French: French
+Georgian: Georgian
+German: German
+Ge'ez: Ge'ez
+Greek: Greek
+Greek, Pontic: Greek, Pontic
+Greek, Ancient: Greek, Ancient
+Gujarati: Gujarati
+Hebrew: Hebrew
+Indic languages: Indic languages
+Indonesian: Indonesian
+Italian: Italian
+Judeo-Arabic: Judeo-Arabic
+Judeo-Italian: Judeo-Italian
+Judeo-Persian: Judeo-Persian
+Judeo-Portuguese: Judeo-Portuguese
+Judeo-Spanish: Judeo-Spanish
+Ladino: Ladino
+Latin: Latin
+Malay: Malay
+No linguistic content; Not applicable: No linguistic content; Not applicable
+Old Bulgarian: Old Bulgarian
+Official Aramaic (700-300 BCE): Official Aramaic (700-300 BCE)
+Persian: Persian
+Portuguese: Portuguese
+Russian: Russian
+Slavic Languages: Slavic Languages
+Spanish: Spanish
+Syriac: Syriac
+Turkish: Turkish
+Turkish, Ottoman (1500-1928): Turkish, Ottoman (1500-1928)
+Urdu: Urdu

--- a/lib/translation_maps/norm_types_to_en.yaml
+++ b/lib/translation_maps/norm_types_to_en.yaml
@@ -1,0 +1,7 @@
+3D: 3D
+Dataset: Dataset
+Image: Image
+Interactive Resource: Interactive Resource
+Sound: Sound
+Text: Text
+Video: Video


### PR DESCRIPTION
## Why was this change made?
Closes #535 
This change adds source language YML files for English so that Arabic translations can be managed in Transifex with QNL's help. See issue for additional context.

I'm not very familiar with dlme-transform, so if these files should live in a different repo (i.e. keeping them in the current directory will interfere with existing workflows), let me know. Transifex is completely agnostic to file path. Thanks!

## Was the documentation (README, API, wiki, ...) updated?
No. I am currently working ondocumentation for our Transifex workflows across repos in [this google doc](https://docs.google.com/document/d/1Zu574lJNM55Diu_F0-aN6bIZ--aOKFw7Bqj0VPiYCNA/edit). I can add a wiki page if that's useful? 
