### PR TITLE
Do not include empty agg_preview

### DIFF
--- a/lib/macros/harvard.rb
+++ b/lib/macros/harvard.rb
@@ -31,7 +31,7 @@ module Macros
       lambda do |record, accumulator, _context|
         id = record.xpath('//*/dc:identifier', dc: NS[:dc])
                    .find { |node| node.text.include?('iiif') || node.text.include?('usethumb=y') }
-        accumulator << id.text unless id.nil?
+        accumulator << { 'wr_id' => [id.text] } unless id.nil?
       end
     end
 

--- a/traject_configs/harvard_ihp_config.rb
+++ b/traject_configs/harvard_ihp_config.rb
@@ -72,12 +72,7 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
     'wr_id' => [extract_harvard('//*/dc:identifier[last()]'), strip]
   )
 end
-to_field 'agg_preview' do |_record, accumulator, context|
-  accumulator << transform_values(
-    context,
-    'wr_id' => [extract_harvard_thumb]
-  )
-end
+to_field 'agg_preview', extract_harvard_thumb
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')


### PR DESCRIPTION
## Why was this change made?

Fixes #466  for harvard. The example in the ticket now produces:

```
{"cho_title":{"none":["Hādhā Thabat al-Shihāb Aḥmad al-ʻAṭṭār : manuscript, 1900"]},"cho_alternative":{"none":["هذا ثبت الشهاب احمد العطار : مخطوطة، 1900"]},"cho_contributor":{"none":["ʻAṭṭār, Aḥmad Fahmī ibn Salīm (copyist.)","عطار، احمد بن عبيد الله، , 1725 or 1726-1803 or 1804"]},"cho_creator":{"en":["ʻAṭṭār, Aḥmad ibn ʻUbayd Allāh , 1725 or 1726-1803 or 1804"]},"cho_date":{"en":["1900"]},"cho_date_range_norm":[1900],"cho_date_range_hijri":[1317,1318],"cho_description":{"en":["Copy completed on 2 Dhū al-Ḥijjah 1317 [April 2, 1900] in the hand of Aḥmad Fahmī ibn Salīm ibn Yāsīn ibn Ḥāmid ibn al-Shihāb Aḥmad al-ʻAṭṭār, most probably in Damascus.","Bound with: Kitāb al-Fawāʼid al-jalīlah fī musalsalāt Ibn ʻAqīlah / Muḥammad ibn Aḥmad ʻAqīlah.","MS Arab 112. Houghton Library, Harvard University.","In Arabic."]},"cho_edm_type":{"en":["Text"],"ar-Arab":["نص"]},"cho_format":{"en":["print","19 leaves, bound ; 20 cm."]},"cho_has_type":{"en":["Manuscript"],"ar-Arab":["مخطوط"]},"cho_language":{"en":["Arabic"],"ar-Arab":["العربية"]},"cho_publisher":{"en":["Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University Houghton Library, Harvard University"]},"cho_relation":{"en":["https://id.lib.harvard.edu/alma/990073652560203941/catalog"]},"cho_subject":{"en":["Hadith--Authorities"]},"agg_data_provider":{"en":["Harvard University's Libraries and Museums"],"ar-Arab":["مكتبات ومتاحف جامعة هارفارد"]},"agg_data_provider_country":{"en":["United States of America"],"ar-Arab":["الولايات المتحدة الامريكيه"]},"agg_provider":{"en":["Harvard University Library"],"ar-Arab":["مكتبة جامعة هارفارد"]},"agg_provider_country":{"en":["United States of America"],"ar-Arab":["الولايات المتحدة الامريكيه"]},"cho_type_facet":{"en":["Text","Text:Manuscript"],"ar-Arab":["نص","نص:مخطوط"]},"id":"oclc:612183334","transform_version":"c9212ad","transform_timestamp":"2020-04-21 21:58:21 +0000","agg_data_provider_collection":"harvard/islamic-heritage-project/data","agg_is_shown_at":{"wr_id":"https://id.lib.harvard.edu/curiosity/islamic-heritage-project/40-990073652560203941"}}
```