### PR TITLE
Fix parenthesis in Arabic language values

### DIFF
--- a/lib/translation_maps/norm_languages_to_ar.yaml
+++ b/lib/translation_maps/norm_languages_to_ar.yaml
@@ -1,5 +1,5 @@
 Amharic: الأمهرية
-Ancient Greek (to 1453): (اليونانية القديمة (حتى 1453 م
+Ancient Greek (to 1453): (حتى ٤٥٣ م) اليونانية القديمة
 Arabic: العربية
 Aramaic: الآرامية
 Armenian: الأرمنية
@@ -8,15 +8,15 @@ Catalan: الكاتالونية
 Classical Syriac: السريانية الكلاسيكية
 Coptic: القبطية
 Dutch; Flemish: هولندي؛ الفلمنكية
-Egyptian (Ancient): (المصرية (القديمة
+Egyptian (Ancient): (القديمة) المصرية
 English: الإنجليزية
 French: الفرنسية
 Georgian: الجورجية
 German: الألمانية
 Ge'ez: الجعزية
 Greek: اليونانية
-Greek, Pontic: (اليونانية (البنطية
-Greek, Ancient: (اليونانية (القديمة
+Greek, Pontic: (البنطية) اليونانية
+Greek, Ancient: (القديمة) اليونانية
 Gujarati: الغوجاراتية
 Hebrew: العبرية
 Indic languages: اللغات الهندية
@@ -32,7 +32,7 @@ Latin: اللاتينية
 Malay: لغة الملايو
 No linguistic content; Not applicable: لا يوجد محتوى لغوي
 Old Bulgarian: البلغارية القديمة
-Official Aramaic (700-300 BCE): (الآرامية الرسمية (من 700 إلى 300 قبل الميلاد
+Official Aramaic (700-300 BCE): (من ٧٠٠ إلى ٣٠٠ قبل الميلاد)  الآرامية الرسمية
 Persian: الفارسية
 Portuguese: البرتغالية
 Russian: الروسية
@@ -40,5 +40,5 @@ Slavic Languages: اللغات السلافية
 Spanish: الأسبانية
 Syriac: السريانية
 Turkish: التركية
-Turkish, Ottoman (1500-1928): (التركية العثمانية (من 1500 إلى 1928
+Turkish, Ottoman (1500-1928): (من ١٥٠٠ إلى ١٩٢٨) التركية العثمانية
 Urdu: الأردية


### PR DESCRIPTION
## Why was this change made?

The parenthesis are misplaced in the Arabic language values, I suspect because they looked the same but were different characters.

## How was this change tested?

I loaded this in the local webapp (docker). The English looks fine but there is no Arabic site in the local version so I can't tell if this will resolve the problem.

## Which documentation and/or configurations were updated?

n/a

