### PR TITLE
Revise turkish type translation map

### DIFF
--- a/lib/translation_maps/turkish-types.yaml
+++ b/lib/translation_maps/turkish-types.yaml
@@ -21,5 +21,5 @@ mektup: Text
 metin: Text
 resim: Image
 yazı: Text
-yazı malzemeleri: Text
+yazı malzemeleri: Image
 yazışma: Text


### PR DESCRIPTION
## Why was this change made?

One value in the Turkish type translation map was incorrectly mapped

## How was this change tested?

Transformed and viewed locally

## Which documentation and/or configurations were updated?

n/a


