### PR TITLE
fix parenthesis in arabic translation map

### DIFF
--- a/lib/translation_maps/norm_languages_to_ar.yaml
+++ b/lib/translation_maps/norm_languages_to_ar.yaml
@@ -1,5 +1,5 @@
 Amharic: الأمهرية
-Ancient Greek (to 1453): (حتى ٤٥٣ م) اليونانية القديمة
+Ancient Greek (to 1453): اليونانية القديمة (حتى ٤٥٣ م)
 Arabic: العربية
 Aramaic: الآرامية
 Armenian: الأرمنية
@@ -8,15 +8,15 @@ Catalan: الكاتالونية
 Classical Syriac: السريانية الكلاسيكية
 Coptic: القبطية
 Dutch; Flemish: هولندي؛ الفلمنكية
-Egyptian (Ancient): (القديمة) المصرية
+Egyptian (Ancient):  المصرية (القديمة)
 English: الإنجليزية
 French: الفرنسية
 Georgian: الجورجية
 German: الألمانية
 Ge'ez: الجعزية
 Greek: اليونانية
-Greek, Pontic: (البنطية) اليونانية
-Greek, Ancient: (القديمة) اليونانية
+Greek, Pontic: اليونانية (البنطي)
+Greek, Ancient: اليونانية (القديمة)
 Gujarati: الغوجاراتية
 Hebrew: العبرية
 Indic languages: اللغات الهندية
@@ -32,7 +32,7 @@ Latin: اللاتينية
 Malay: لغة الملايو
 No linguistic content; Not applicable: لا يوجد محتوى لغوي
 Old Bulgarian: البلغارية القديمة
-Official Aramaic (700-300 BCE): (من ٧٠٠ إلى ٣٠٠ قبل الميلاد)  الآرامية الرسمية
+Official Aramaic (700-300 BCE):  الآرامية الرسمية (من ٧٠٠ إلى ٣٠٠ قبل الميلاد)
 Persian: الفارسية
 Portuguese: البرتغالية
 Russian: الروسية
@@ -40,5 +40,5 @@ Slavic Languages: اللغات السلافية
 Spanish: الأسبانية
 Syriac: السريانية
 Turkish: التركية
-Turkish, Ottoman (1500-1928): (من ١٥٠٠ إلى ١٩٢٨) التركية العثمانية
+Turkish, Ottoman (1500-1928):  التركية العثمانية (من ١٥٠٠ إلى ١٩٢٨) 
 Urdu: الأردية


### PR DESCRIPTION
## Why was this change made?

Parenthesis were on the wrong side

## How was this change tested?

Can't test Arabic language changes locally

## Which documentation and/or configurations were updated?

n/a

