### PR TITLE
Add a CSIC macro to extract the proper is_shown_at from the simurg URL

### DIFF
--- a/lib/macros/csic.rb
+++ b/lib/macros/csic.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'byebug'
+
+# Macros for Traject transformations.
+module Macros
+  # Macro to extract only the 856u field that includes the simurg url for CSIC.
+  module Csic
+    # Remove any 856u fields that do not include the simurg URL for CISC
+    # @return [Proc] a proc that traject can call for each record
+    def extract_preview
+      lambda { |_record, accumulator, _context|
+        accumulator.filter! { |val| val.include?('simurg.bibliotecas.csic.es') }
+      }
+    end
+  end
+end

--- a/lib/macros/csic.rb
+++ b/lib/macros/csic.rb
@@ -10,7 +10,7 @@ module Macros
     # @return [Proc] a proc that traject can call for each record
     def extract_preview
       lambda { |_record, accumulator, _context|
-        accumulator.filter! { |val| val.include?('simurg.bibliotecas.csic.es') }
+        accumulator&.filter! { |val| val.include?('simurg.bibliotecas.csic.es') }
       }
     end
   end

--- a/spec/lib/traject/macros/csic_spec.rb
+++ b/spec/lib/traject/macros/csic_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'macros/csic'
+
+RSpec.describe Macros::Csic do
+  let(:klass) do
+    Class.new do
+      include Macros::Csic
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe '#extract_preview' do
+    let(:urls1) do
+      ['http://aleph.csic.es/imagenes/mad01/0006_PMSC/P_001354598_792189_V00.pdf',
+       'http://simurg.bibliotecas.csic.es/viewer/image/CSIC001354598/1/',
+       'http://aleph.csic.es/imagenes/mad01/0006_PMSC/html/001354598.html']
+    end
+
+    let(:urls2) do
+      ['http://aleph.csic.es/imagenes/mad01/0006_PMSC/P_001354598_792189_V00.pdf',
+       'http://aleph.csic.es/imagenes/mad01/0006_PMSC/html/001354598.html']
+    end
+
+    context 'when a simurg URL 856u exists' do
+      it 'returns only the simurg URL record' do
+        callable = instance.extract_preview
+        expect(callable.call(nil, urls1, nil)).to eq ['http://simurg.bibliotecas.csic.es/viewer/image/CSIC001354598/1/']
+      end
+    end
+
+    context 'when a simurg URL 856u does not exists' do
+      it 'returns only the simurg URL record' do
+        callable = instance.extract_preview
+        expect(callable.call(nil, urls2, nil)).to eq []
+      end
+    end
+
+    context 'when no 856u fields exists' do
+      it 'returns an empty array' do
+        callable = instance.extract_preview
+        expect(callable.call(nil, nil, nil)).to eq nil
+      end
+    end
+  end
+end

--- a/traject_configs/csic_config.rb
+++ b/traject_configs/csic_config.rb
@@ -3,6 +3,7 @@
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
 require 'macros/collection'
+require 'macros/csic'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/dlme_marc'
@@ -15,6 +16,7 @@ require 'traject/macros/marc_format_classifier'
 require 'traject_plus'
 
 extend Macros::Collection
+extend Macros::Csic
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::DlmeMarc
@@ -90,7 +92,7 @@ to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
 # Agg Additional
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
-  accumulator << transform_values(context, 'wr_id' => [extract_marc('856u'), first_only])
+  accumulator << transform_values(context, 'wr_id' => [extract_marc('856u'), extract_preview])
 end
 
 # NOTE:  add the below to collection specific config


### PR DESCRIPTION
## Why was this change made?

Extracts the expected 856u field that includes the appropriate URL desired for agg_is_shown_at. There can be several 856 blocks, with several values for 856u, this filters out anything that does not include the simurg url.

## How was this change tested?

Unit test, manual verification by @jacobthill 

## Which documentation and/or configurations were updated?

N/A

