### PR TITLE
Fix sub types

### DIFF
--- a/traject_configs/auc_university_on_square_coll7_config.rb
+++ b/traject_configs/auc_university_on_square_coll7_config.rb
@@ -57,9 +57,9 @@ to_field 'cho_edm_type', extract_oai('dc:type'),
          split(';'), strip, transform(&:downcase), normalize_type, translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_format', extract_oai('dc:format'), strip, lang('en')
 to_field 'cho_has_type', extract_oai('dc:type'),
-         split(';'), strip, transform(&:downcase), translation_map('norm_has_type_to_en'), lang('en')
+         split(';'), strip, translation_map('norm_has_type_to_en'), lang('en')
 to_field 'cho_has_type', extract_oai('dc:type'),
-         split(';'), strip, transform(&:downcase), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+         split(';'), strip, translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_language', extract_oai('dc:language'), split(';'),
          split(','), strip, transform(&:downcase), normalize_language, lang('en')
 to_field 'cho_language', extract_oai('dc:language'), split(';'),


### PR DESCRIPTION
## Why was this change made?

The extracted cho_has_type values were not found in the translation map so nothing was getting passed through to the IR. This removes the `downcase` so that the extracted values are found and mapped.

## How was this change tested?

Transformed and viewed locally.

## Which documentation and/or configurations were updated?

n/a


