### PR TITLE
Pull macro test code that does not need to vary into test setup

### DIFF
--- a/spec/lib/traject/macros/csic_spec.rb
+++ b/spec/lib/traject/macros/csic_spec.rb
@@ -3,43 +3,48 @@
 require 'macros/csic'
 
 RSpec.describe Macros::Csic do
+  subject(:macro_result) { callable.call(nil, urls, nil) }
+
+  let(:callable) { klass.new.extract_preview }
   let(:klass) do
     Class.new do
       include Macros::Csic
     end
   end
-  let(:instance) { klass.new }
 
   describe '#extract_preview' do
-    let(:urls1) do
-      ['http://aleph.csic.es/imagenes/mad01/0006_PMSC/P_001354598_792189_V00.pdf',
-       'http://simurg.bibliotecas.csic.es/viewer/image/CSIC001354598/1/',
-       'http://aleph.csic.es/imagenes/mad01/0006_PMSC/html/001354598.html']
-    end
+    context 'when a simurg URL exists' do
+      let(:urls) do
+        [
+          'http://aleph.csic.es/imagenes/mad01/0006_PMSC/P_001354598_792189_V00.pdf',
+          'http://simurg.bibliotecas.csic.es/viewer/image/CSIC001354598/1/',
+          'http://aleph.csic.es/imagenes/mad01/0006_PMSC/html/001354598.html'
+        ]
+      end
 
-    let(:urls2) do
-      ['http://aleph.csic.es/imagenes/mad01/0006_PMSC/P_001354598_792189_V00.pdf',
-       'http://aleph.csic.es/imagenes/mad01/0006_PMSC/html/001354598.html']
-    end
-
-    context 'when a simurg URL 856u exists' do
-      it 'returns only the simurg URL record' do
-        callable = instance.extract_preview
-        expect(callable.call(nil, urls1, nil)).to eq ['http://simurg.bibliotecas.csic.es/viewer/image/CSIC001354598/1/']
+      it 'returns only the simurg URL record(s)' do
+        expect(macro_result).to eq ['http://simurg.bibliotecas.csic.es/viewer/image/CSIC001354598/1/']
       end
     end
 
-    context 'when a simurg URL 856u does not exists' do
-      it 'returns only the simurg URL record' do
-        callable = instance.extract_preview
-        expect(callable.call(nil, urls2, nil)).to eq []
+    context 'when a simurg URL does not exist' do
+      let(:urls) do
+        [
+          'http://aleph.csic.es/imagenes/mad01/0006_PMSC/P_001354598_792189_V00.pdf',
+          'http://aleph.csic.es/imagenes/mad01/0006_PMSC/html/001354598.html'
+        ]
       end
-    end
 
-    context 'when no 856u fields exists' do
       it 'returns an empty array' do
-        callable = instance.extract_preview
-        expect(callable.call(nil, nil, nil)).to eq nil
+        expect(macro_result).to eq []
+      end
+    end
+
+    context 'when passed a URLs value that is blank (empty, nil)' do
+      let(:urls) { nil }
+
+      it 'returns nil' do
+        expect(macro_result).to eq nil
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To make it easier to see how to extend this test code in the future and use RSpec machinery.

## How was this change tested?

Unit test.

## Which documentation and/or configurations were updated?

None.

