### PR TITLE
Specify python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV BUNDLER_VERSION 2.0.2
 RUN apk add --no-cache \
     curl \
     zip \
-    python \
+    python3 \
     libxml2-dev \
     libxslt-dev \
     jq \
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
       build-base \
     && apk add --no-cache --virtual python-dependencies \
     py-pip \
-    python-dev \
+    python3-dev \
     && pip install awscli \
     && apk del python-dependencies \
     && gem install bundler


### PR DESCRIPTION

## Why was this change made?

Because the base image is now based on Alpine 3.12 which requires this change. See https://stackoverflow.com/questions/62169568/docker-alpine-linux-python-missing


## How was this change tested?

n/a

## Which documentation and/or configurations were updated?
n/a


