### PR TITLE
user pip3 to install python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache \
     && apk add --no-cache --virtual python-dependencies \
     py-pip \
     python3-dev \
-    && pip install awscli \
+    && pip3 install six \
+    && pip3 install awscli \
     && apk del python-dependencies \
     && gem install bundler
 


### PR DESCRIPTION
## Why was this change made?

Fixes missing awscli command after python3 upgrade.

## How was this change tested?

manually in dev

## Which documentation and/or configurations were updated?



