### PR TITLE
Do not install six dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apk add --no-cache \
     py-pip \
     python3-dev \
     && pip3 install awscli \
-    && pip3 install --ignore-installed six \
     && apk del python-dependencies \
     && gem install bundler
 


### PR DESCRIPTION
## Why was this change made?

The pip3 installation of awscli makes the six installation unnecessary. 


## How was this change tested?

Manually in AWS Dev


## Which documentation and/or configurations were updated?



