### PR TITLE
Remove alternate tiles from main title field

### DIFF
--- a/traject_configs/harvard_scw_config.rb
+++ b/traject_configs/harvard_scw_config.rb
@@ -40,7 +40,7 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # CHO Required
-to_field 'cho_title', extract_mods('/*/mods:titleInfo/mods:title'), lang('en')
+to_field 'cho_title', extract_mods('/*/mods:titleInfo/mods:title'), first_only, lang('en')
 to_field 'id', generate_mods_id
 
 # CHO Other


### PR DESCRIPTION
## Why was this change made?

There were too many alternate titles displayed in the main title field.

## How was this change tested?

locally

## Which documentation and/or configurations were updated?

n/a

