### PR TITLE
Map LOC collections

### DIFF
--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -877,12 +877,12 @@
     "settings": {
       "agg_provider": "Library of Congress",
       "agg_provider_country": "United States of America",
-      "agg_data_provider": "Library of Congress",
-      "agg_data_provider_country": "United States of America",
+      "agg_data_provider": "Libraries of the Greek and Armenian Patriarchates in Jerusalem",
+      "agg_data_provider_country": "",
       "agg_provider_ar": "مكتبة الكونغرس",
       "agg_provider_country_ar": "الولايات المتحدة الامريكيه",
-      "agg_data_provider_ar": "مكتبة الكونغرس",
-      "agg_data_provider_country_ar": "الولايات المتحدة الامريكيه",
+      "agg_data_provider_ar": "مكتبات البطريركية اليونانية والأرمنية في القدس",
+      "agg_data_provider_country_ar": "",
       "inst_id": "loc"
     }
   },
@@ -917,12 +917,12 @@
     "settings": {
       "agg_provider": "Library of Congress",
       "agg_provider_country": "United States of America",
-      "agg_data_provider": "Library of Congress",
-      "agg_data_provider_country": "United States of America",
+      "agg_data_provider": "St. Catherine's Monastery, Mount Sinai",
+      "agg_data_provider_country": "Egypt",
       "agg_provider_ar": "مكتبة الكونغرس",
-      "agg_provider_country_ar": "الولايات المتحدة الامريكيه",
+      "agg_provider_country_ar": "دير سانت كاترين ، جبل سيناء",
       "agg_data_provider_ar": "مكتبة الكونغرس",
-      "agg_data_provider_country_ar": "الولايات المتحدة الامريكيه",
+      "agg_data_provider_country_ar": "مصر",
       "inst_id": "loc"
     }
   },

--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -132,7 +132,7 @@ module Macros
     end
 
     # Returns the value extracted by 'to_field' reformated as a hash with accompanying BCP47 language code.
-    # Should only be used when metadata is known to be either Arabic in Arabic script of English.
+    # Should only be used when metadata is known to be either Arabic in Arabic script or English.
     # Any other values will not parse correctly.
     # @return [Proc] a proc that traject can call for each record
     # @example
@@ -142,6 +142,38 @@ module Macros
         extracted_string = accumulator[0]
         if extracted_string
           script = extracted_string.match?(/[ضصثقفغعهخحمنتالبيسشظطذدزرو]/) ? 'ar-Arab' : 'en'
+          accumulator.replace([{ language: script.to_s, values: [extracted_string] }])
+        end
+      end
+    end
+
+    # Returns the value extracted by 'to_field' reformated as a hash with accompanying BCP47 language code.
+    # Should only be used when metadata is known to be either Persian in Arabic script or an unpredictable language.
+    # Any other values will not parse correctly.
+    # @return [Proc] a proc that traject can call for each record
+    # @example
+    #  persian_or_none => {'fa-Arab': ['نظامنامۀ مقياسات']}
+    def persian_or_none
+      lambda do |_record, accumulator|
+        extracted_string = accumulator[0]
+        if extracted_string
+          script = extracted_string.match?(/[ضصثقفغعهخحمنتالبيسشظطذدزرو]/) ? 'fa-Arab' : 'none'
+          accumulator.replace([{ language: script.to_s, values: [extracted_string] }])
+        end
+      end
+    end
+
+    # Returns the value extracted by 'to_field' reformated as a hash with accompanying BCP47 language code.
+    # Should only be used when metadata is known to be either Arabic in Arabic script or none.
+    # Any other values will not parse correctly.
+    # @return [Proc] a proc that traject can call for each record
+    # @example
+    #  naive_language_extractor => {'ar-Arab': ['من كتب محمد بن محمد الكبسي. لقطة رقم (1).']}
+    def arabic_or_none
+      lambda do |_record, accumulator|
+        extracted_string = accumulator[0]
+        if extracted_string
+          script = extracted_string.match?(/[ضصثقفغعهخحمنتالبيسشظطذدزرو]/) ? 'ar-Arab' : 'none'
           accumulator.replace([{ language: script.to_s, values: [extracted_string] }])
         end
       end

--- a/lib/translation_maps/has_type.yaml
+++ b/lib/translation_maps/has_type.yaml
@@ -2,6 +2,7 @@
 archival file: Other Document
 archival item: Other Document
 archivalfile: Other Document
+book: Book
 certificate: Other Document
 diagram: Other Document
 drawing: Drawing
@@ -12,10 +13,13 @@ letter book: Letter
 list: Other Document
 manuscript: Manuscript
 manuscript item: Manuscript
+manuscript/mixed material: Manuscript
 map: Map
 newspaper article: Newspaper
 note: Other Document
 painting: Painting
+periodical: Periodical
+photo, print, drawing: Photograph
 photograph: Photograph
 plan: Other Document
 print: Visual Art

--- a/traject_configs/loc_abdul_hamid_ii_books_config.rb
+++ b/traject_configs/loc_abdul_hamid_ii_books_config.rb
@@ -8,6 +8,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
+require 'macros/path_to_file'
 require 'macros/timestamp'
 require 'macros/version'
 
@@ -16,6 +17,7 @@ extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::PathToFile
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -30,12 +32,15 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
+# File path
+to_field 'dlme_source_file', path_to_file
+
 # Cho Required
 to_field 'id', extract_json('.id')
 to_field 'cho_title', extract_json('.item.title'), strip
-to_field 'cho_alternative', extract_json('.item.other_title[0]'), strip
 
 # Cho Other
+to_field 'cho_alternative', extract_json('.item.other_title[0]'), strip
 to_field 'cho_contributor', extract_json('.item.contributors[0]'), strip, lang('en')
 to_field 'cho_date', extract_json('.item.date'), strip
 to_field 'cho_date_range_norm', extract_json('.item.date'), strip, parse_range
@@ -46,17 +51,18 @@ to_field 'cho_description', extract_json('.item.notes[0]'), strip, lang('en')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('.item.medium[0]'), strip, lang('en')
-to_field 'cho_has_type', literal('Book'), lang('en')
-to_field 'cho_has_type', literal('Book'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.item.call_number[0]'), strip
 to_field 'cho_identifier', extract_json('.number_lccn[0]'), strip
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
-to_field 'cho_is_part_of', extract_json('.partof[0]'), strip, lang('en')
-# to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, lang('en')
+to_field 'cho_is_part_of', literal('Abdul-Hamid II Collection of Books and Serials Gifted to the Library of Congress'), strip, lang('en')
+to_field 'cho_language', literal('.language[0]'), strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_publisher', extract_json('.item.created_published[0]'), strip, lang('en')
 to_field 'cho_spatial', extract_json('.location[0]'), strip, lang('en')
-to_field 'cho_subject', extract_json('.subjects[0]'), strip, lang('en')
-to_field 'cho_type', extract_json('.item.format[0]'), strip, lang('en')
+to_field 'cho_subject', extract_json('.subject[0]'), strip, lang('en')
+to_field 'cho_type', extract_json('.original_format[0]'), strip, lang('en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -67,13 +73,15 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.id'), strip]
+    'wr_id' => [extract_json('.id'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.resources[0].image'), strip]
+    'wr_id' => [extract_json('.resources[0].image'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_abdul_hamid_ii_photos_config.rb
+++ b/traject_configs/loc_abdul_hamid_ii_photos_config.rb
@@ -8,6 +8,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
+require 'macros/path_to_file'
 require 'macros/timestamp'
 require 'macros/version'
 
@@ -16,6 +17,7 @@ extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::PathToFile
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -30,9 +32,12 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
+# File path
+to_field 'dlme_source_file', path_to_file
+
 # Cho Required
 to_field 'id', extract_json('.id')
-to_field 'cho_title', extract_json('.title'), strip, lang('en')
+to_field 'cho_title', extract_json('.title'), strip, gsub('[', ''), gsub(']', ''), lang('en')
 
 # Cho Other
 to_field 'cho_contributor', extract_json('.contributor[0]'), strip, lang('en')
@@ -43,12 +48,13 @@ to_field 'cho_dc_rights', literal("The Library of Congress does not own rights t
 to_field 'cho_description', extract_json('.description[0]'), strip, lang('en')
 to_field 'cho_edm_type', literal('Image'), lang('en')
 to_field 'cho_edm_type', literal('Image'), translation_map('norm_types_to_ar'), lang('ar-Arab')
-to_field 'cho_has_type', literal('Photograph'), lang('en')
-to_field 'cho_has_type', literal('Photograph'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
-to_field 'cho_is_part_of', extract_json('.partof[0]'), strip, lang('en')
+to_field 'cho_is_part_of', literal('Abdul Hamid II Collection'), lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_spatial', extract_json('.location[0]'), strip, lang('en')
 to_field 'cho_subject', extract_json('.subject[0]'), strip, lang('en')
 to_field 'cho_type', extract_json('.online_format[0]'), strip, lang('en')
 

--- a/traject_configs/loc_el_taher_config.rb
+++ b/traject_configs/loc_el_taher_config.rb
@@ -8,6 +8,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
+require 'macros/path_to_file'
 require 'macros/timestamp'
 require 'macros/version'
 
@@ -16,6 +17,7 @@ extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::PathToFile
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -30,10 +32,13 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
+# File path
+to_field 'dlme_source_file', path_to_file
+
 # Cho Required
 to_field 'id', extract_json('.id')
-to_field 'cho_title', extract_json('.item.title'), strip
-to_field 'cho_alternative', extract_json('.item.other_title[0]'), strip
+to_field 'cho_title', extract_json('.item.title'), strip, arabic_or_none
+to_field 'cho_title', extract_json('.item.other_title[0]'), strip, arabic_or_none
 
 # Cho Other
 to_field 'cho_contributor', extract_json('.item.contributors[0]'), strip, lang('en')
@@ -46,17 +51,18 @@ to_field 'cho_description', extract_json('.item.notes[0]'), strip, lang('en')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('.item.medium[0]'), strip, lang('en')
-to_field 'cho_has_type', literal('Book'), lang('en')
-to_field 'cho_has_type', literal('Book'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.item.call_number[0]'), strip
 to_field 'cho_identifier', extract_json('.number_lccn[0]'), strip
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
-to_field 'cho_is_part_of', extract_json('.partof[0]'), strip, lang('en')
+to_field 'cho_is_part_of', literal('Eltaher Collection'), lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_publisher', extract_json('.item.created_published[0]'), strip, lang('en')
 to_field 'cho_spatial', extract_json('.location[0]'), strip, lang('en')
 to_field 'cho_subject', extract_json('.subject[0]'), strip
-to_field 'cho_type', extract_json('.item.format[0]'), strip, lang('en')
+to_field 'cho_type', extract_json('.original_format[0]'), strip, lang('en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -73,7 +79,7 @@ end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('image_url[0]'), strip, prepend('http:')]
+    'wr_id' => [extract_json('.resources[0].image'), strip]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_greek_and_armenian_patriarchates_config.rb
+++ b/traject_configs/loc_greek_and_armenian_patriarchates_config.rb
@@ -8,6 +8,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
+require 'macros/path_to_file'
 require 'macros/timestamp'
 require 'macros/version'
 
@@ -16,6 +17,7 @@ extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::PathToFile
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -30,22 +32,25 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
+# File path
+to_field 'dlme_source_file', path_to_file
+
 # Cho Required
 to_field 'id', extract_json('.id')
 to_field 'cho_title', extract_json('.title'), strip, lang('en')
 
 # Cho Other
+to_field 'cho_contributor', extract_json('.contributor[0]'), strip, lang('en')
 to_field 'cho_date', extract_json('.date'), strip
 to_field 'cho_date_range_norm', extract_json('.date'), strip, parse_range
 to_field 'cho_date_range_hijri', extract_json('.date'), strip, parse_range, hijri_range
-to_field 'cho_dc_rights', literal('The contents of the Library of Congress Sultan Abdul-Hamid II Collection are in the public domain and are free to use and reuse. Credit Line: Library of Congress, African and Middle East Division, Sultan Abdul-Hamid II Collection.'), lang('en')
-to_field 'cho_description', extract_json('.description[0]'), strip, lang('en')
+to_field 'cho_dc_rights', literal('The contents of the Manuscripts in the Libraries of the Greek and Armenian Patriarchates in Jerusalem are in the public domain and are free to use and reuse. Credit Line: Library of Congress, African and Middle East Division, Manuscripts in the Libraries of the Greek and Armenian Patriarchates in Jerusalem.'), lang('en')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
-to_field 'cho_has_type', literal('Manuscript'), lang('en')
-to_field 'cho_has_type', literal('Manuscript'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
-to_field 'cho_is_part_of', extract_json('.partof[0]'), strip, lang('en')
+to_field 'cho_is_part_of', literal('Manuscripts in the Libraries of the Greek and Armenian Patriarchates in Jerusalem'), lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
 to_field 'cho_subject', extract_json('.subject[0]'), strip, lang('en')
@@ -64,13 +69,15 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.id'), strip]
+    'wr_id' => [extract_json('.id'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.image_url[0]'), strip]
+    'wr_id' => [extract_json('.image_url[0]'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_persian_config.rb
+++ b/traject_configs/loc_persian_config.rb
@@ -41,7 +41,6 @@ to_field 'cho_title', extract_json('.item.title'), strip, persian_or_none
 to_field 'cho_title', extract_json('.item.other_title[0]'), strip, persian_or_none
 
 # Cho Other
-# to_field 'cho_alternative', extract_json('.item.other_title[0]'), strip
 to_field 'cho_contributor', extract_json('item.contributors[0]'), strip, lang('en')
 to_field 'cho_date', extract_json('item.date'), strip
 to_field 'cho_date_range_norm', extract_json('item.date'), strip, parse_range

--- a/traject_configs/loc_persian_config.rb
+++ b/traject_configs/loc_persian_config.rb
@@ -8,6 +8,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
+require 'macros/path_to_file'
 require 'macros/timestamp'
 require 'macros/version'
 
@@ -16,6 +17,7 @@ extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::PathToFile
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -30,12 +32,16 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
+# File path
+to_field 'dlme_source_file', path_to_file
+
 # Cho Required
 to_field 'id', extract_json('.id')
-to_field 'cho_title', extract_json('.item.title'), strip
+to_field 'cho_title', extract_json('.item.title'), strip, persian_or_none
+to_field 'cho_title', extract_json('.item.other_title[0]'), strip, persian_or_none
 
 # Cho Other
-to_field 'cho_alternative', extract_json('.item.other_title[0]'), strip
+# to_field 'cho_alternative', extract_json('.item.other_title[0]'), strip
 to_field 'cho_contributor', extract_json('item.contributors[0]'), strip, lang('en')
 to_field 'cho_date', extract_json('item.date'), strip
 to_field 'cho_date_range_norm', extract_json('item.date'), strip, parse_range
@@ -46,17 +52,18 @@ to_field 'cho_description', extract_json('.item.notes[0]'), strip, lang('en')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('.item.medium[0]'), strip, lang('en')
-to_field 'cho_has_type', literal('Manuscript'), lang('en')
-to_field 'cho_has_type', literal('Manuscript'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.item.call_number[0]'), strip
 to_field 'cho_identifier', extract_json('.number_lccn[0]'), strip
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
-to_field 'cho_is_part_of', extract_json('.partof[0]'), strip, lang('en')
+to_field 'cho_is_part_of', literal('Persian Language Rare Materials'), lang('en')
 to_field 'cho_language', extract_json('.item.language[0]'), strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('.item.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
-to_field 'cho_spatial', extract_json('.location[0]'), strip, lang('en')
-to_field 'cho_subject', extract_json('item.subjects[0]'), strip, lang('en')
-to_field 'cho_type', extract_json('.item.format[0]'), strip, lang('en')
+to_field 'cho_publisher', extract_json('.item.created_published[0]'), strip, lang('en')
+to_field 'cho_spatial', extract_json('.location_country[0]'), strip, lang('en')
+to_field 'cho_subject', extract_json('.item.subjects[0]'), strip, lang('en')
+to_field 'cho_type', extract_json('.original_format[0]'), strip, lang('en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -67,13 +74,15 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.id'), strip]
+    'wr_id' => [extract_json('.id'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.resources[0].image'), strip]
+    'wr_id' => [extract_json('.resources[0].image'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_st_catherines_monastery_config.rb
+++ b/traject_configs/loc_st_catherines_monastery_config.rb
@@ -8,6 +8,7 @@ require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
 require 'macros/normalize_language'
+require 'macros/path_to_file'
 require 'macros/timestamp'
 require 'macros/version'
 
@@ -16,6 +17,7 @@ extend Macros::DateParsing
 extend Macros::DLME
 extend Macros::EachRecord
 extend Macros::NormalizeLanguage
+extend Macros::PathToFile
 extend Macros::Timestamp
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -30,6 +32,9 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
+# File path
+to_field 'dlme_source_file', path_to_file
+
 # Cho Required
 to_field 'id', extract_json('.id')
 to_field 'cho_title', extract_json('.item.title'), strip, lang('en')
@@ -43,15 +48,16 @@ to_field 'cho_description', extract_json('.item.notes[0]'), strip, lang('en')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('.item.medium[0]'), strip, lang('en')
-to_field 'cho_has_type', extract_json('.item.format'), strip, lang('en')
-to_field 'cho_has_type', extract_json('.item.format'), strip, translation_map('norm_has_type_to_ar'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.item.call_number[0]'), strip
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
-to_field 'cho_is_part_of', extract_json('.partof[0]'), strip, lang('en')
-to_field 'cho_language', extract_json('language[0]'), strip, normalize_language, lang('en')
+to_field 'cho_is_part_of', literal("Manuscripts in St. Catherine's Monastery, Mount Sinai"), lang('en')
+to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_publisher', extract_json('.item.created_published[0]'), strip, lang('en')
 to_field 'cho_subject', extract_json('.subject[0]'), strip, lang('en')
-to_field 'cho_type', extract_json('.item.format'), strip, lang('en')
+to_field 'cho_has_type', extract_json('.original_format[0]'), strip, lang('en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -62,13 +68,15 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.id'), strip]
+    'wr_id' => [extract_json('.id'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.resources[0].image'), strip]
+    'wr_id' => [extract_json('.resources[0].image'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')


### PR DESCRIPTION
## Why was this change made?

These collections are new to DLME. Mapping started a few months back but wasn't finished. Maps six collections, adds new language detection macros to assign language values to metadata fields (these will be broken out of dlme.rb in the future), updates metadata settings (one country intentionally left blank) and translation map.

## How was this change tested?

Locally tested as much as possible in the docker app. Also used mapping analysis scripts.

## Which documentation and/or configurations were updated?

n/a

