### PR TITLE
Revise LoC mapping

### DIFF
--- a/traject_configs/loc_abdul_hamid_ii_books_config.rb
+++ b/traject_configs/loc_abdul_hamid_ii_books_config.rb
@@ -57,8 +57,8 @@ to_field 'cho_identifier', extract_json('.item.call_number[0]'), strip
 to_field 'cho_identifier', extract_json('.number_lccn[0]'), strip
 to_field 'cho_identifier', extract_json('.shelf_id'), strip
 to_field 'cho_is_part_of', literal('Abdul-Hamid II Collection of Books and Serials Gifted to the Library of Congress'), strip, lang('en')
-to_field 'cho_language', literal('.language[0]'), strip, normalize_language, lang('en')
-to_field 'cho_language', extract_json('.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
+to_field 'cho_language', extract_json('.item.language[0]'), strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.item.language[0]'), strip, normalize_language, translation_map('norm_languages_to_ar'), lang('ar-Arab')
 to_field 'cho_publisher', extract_json('.item.created_published[0]'), strip, lang('en')
 to_field 'cho_spatial', extract_json('.location[0]'), strip, lang('en')
 to_field 'cho_subject', extract_json('.subject[0]'), strip, lang('en')
@@ -80,8 +80,8 @@ end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.resources[0].image'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_id' => [extract_json('.image_url[0]'), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_abdul_hamid_ii_photos_config.rb
+++ b/traject_configs/loc_abdul_hamid_ii_photos_config.rb
@@ -46,6 +46,7 @@ to_field 'cho_date_range_norm', extract_json('.date'), strip, parse_range
 to_field 'cho_date_range_hijri', extract_json('.date'), strip, parse_range, hijri_range
 to_field 'cho_dc_rights', literal("The Library of Congress does not own rights to material in its collections. Therefore, it does not license or charge permission fees for use of such material and cannot grant or deny permission to publish or otherwise distribute the material. Ultimately, it is the researcher's obligation to assess copyright or other use restrictions and obtain permission from third parties when necessary before publishing or otherwise distributing materials found in the Library's collections. For information about reproducing, publishing, and citing material from this collection, as well as access to the original items, see: Abdul Hamid II Collection - Rights and Restrictions Information."), lang('en')
 to_field 'cho_description', extract_json('.description[0]'), strip, lang('en')
+to_field 'cho_description', extract_json('.item.notes[0]'), strip, lang('en')
 to_field 'cho_edm_type', literal('Image'), lang('en')
 to_field 'cho_edm_type', literal('Image'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')

--- a/traject_configs/loc_greek_and_armenian_patriarchates_config.rb
+++ b/traject_configs/loc_greek_and_armenian_patriarchates_config.rb
@@ -70,14 +70,14 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.id'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_id' => [extract_json('.image_url[0]'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_id' => [extract_json('.image_url[0]'), strip, prepend('https:')],
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_persian_config.rb
+++ b/traject_configs/loc_persian_config.rb
@@ -74,14 +74,14 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.id'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.resources[0].image'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/loc_st_catherines_monastery_config.rb
+++ b/traject_configs/loc_st_catherines_monastery_config.rb
@@ -69,14 +69,14 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.id'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.resources[0].image'), strip],
-    'wr_is_referenced_by' => [extract_json('.id'), strip, append('manifest.json')]
+    'wr_is_referenced_by' => [extract_json('.id'), strip, gsub('http', 'https'), append('manifest.json')]
   )
 end
 to_field 'agg_provider', provider, lang('en')


### PR DESCRIPTION
## Why was this change made?

iiif manifest urls weren't displaying for some collections because urls were http instead of https, language values weren't present in one collection, description field missing in one collection.


## How was this change tested?

Tested language and description field with local scripts. No way to test iiif since the local docker app displays iiif manifests with http urls.

## Which documentation and/or configurations were updated?

n/a

