### PR TITLE
fix edm_type

### DIFF
--- a/traject_configs/loc_el_taher_config.rb
+++ b/traject_configs/loc_el_taher_config.rb
@@ -39,8 +39,8 @@ to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', extract_json('.id')
-to_field 'cho_title', extract_json('.item.title'), strip, arabic_or_none
-to_field 'cho_title', extract_json('.item.other_title[0]'), strip, arabic_or_none
+to_field 'cho_title', extract_json('.item.title'), strip, gsub('/', ''), arabic_or_none
+to_field 'cho_title', extract_json('.item.other_title[0]'), strip, gsub('/', ''), arabic_or_none
 
 # Cho Other
 to_field 'cho_contributor', extract_json('.item.contributors[0]'), strip, lang('en')
@@ -50,8 +50,8 @@ to_field 'cho_date_range_hijri', extract_json('.item.date'), strip, parse_range,
 to_field 'cho_dc_rights', literal('The Library of Congress presents the Eltaher Pamphlet Collection for educational and research purposes in accordance with fair use under United States copyright law. Researchers should watch for modern documents that may be copyrighted (for example, published in the United States less than 95 years ago, or unpublished and the author died less than 70 years ago). Rights assessment is your responsibility. The written permission of the copyright owners in materials not in the public domain is required for distribution, reproduction, or other use of protected items beyond that allowed by fair use or other statutory exemptions. There may also be content that is protected under the copyright or neighboring-rights laws of other nations. Permissions may additionally be required from holders of other rights (such as publicity and/or privacy rights). Whenever possible, we provide information that we have about copyright owners and related matters in the catalog records, finding aids and other texts that accompany collections. However, the information we have may not be accurate or complete. More about Copyright and other Restrictions. For guidance about compiling full citations consult Citing Primary Sources. Credit Line: Library of Congress, African and Middle East Division, Eltaher Pamphlet Collection.'), lang('en')
 to_field 'cho_description', extract_json('.description[0]'), strip, lang('en')
 to_field 'cho_description', extract_json('.item.notes[0]'), strip, lang('en')
-to_field 'cho_edm_type', literal('Text'), lang('en')
-to_field 'cho_edm_type', literal('Text'), translation_map('norm_types_to_ar'), lang('ar-Arab')
+to_field 'cho_edm_type', extract_json('.item.format[0]'), strip, translation_map('types'), lang('en')
+to_field 'cho_edm_type', extract_json('.item.format[0]'), strip, translation_map('types'), translation_map('norm_types_to_ar'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('.item.medium[0]'), strip, lang('en')
 to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), lang('en')
 to_field 'cho_has_type', extract_json('.original_format[0]'), strip, translation_map('has_type'), translation_map('norm_has_type_to_ar'), lang('ar-Arab')


### PR DESCRIPTION
## Why was this change made?

Fix a few errors in LOC el-Taher collection
- remove trailing backslash in title field
- one photograph had a cho_edm_type value of 'Text' instead of 'Image'.

## How was this change tested?

Local transform viewed in the dev site.

## Which documentation and/or configurations were updated?

loc_el_taher_config.rb, no documentation update necessary

