### PR TITLE
Revise, add macros and tests for missing titles

### DIFF
--- a/lib/macros/aub.rb
+++ b/lib/macros/aub.rb
@@ -10,9 +10,6 @@ module Macros
     }.freeze
     private_constant :NS
 
-    PREFIX = '/oai_dc:dc'
-    private_constant :PREFIX
-
     include Traject::Macros::NokogiriMacros
 
     # Extracts values for the given xpath which is prefixed with oai and oai_dc wrappers

--- a/spec/lib/traject/macros/dlme_spec.rb
+++ b/spec/lib/traject/macros/dlme_spec.rb
@@ -3,6 +3,15 @@
 require 'macros/dlme'
 
 RSpec.describe Macros::DLME do
+  subject(:indexer) do
+    Traject::Indexer.new.tap do |indexer|
+      indexer.instance_eval do
+        extend Macros::DLME
+        extend TrajectPlus::Macros
+      end
+    end
+  end
+
   let(:klass) do
     Class.new do
       include TrajectPlus::Macros
@@ -10,6 +19,22 @@ RSpec.describe Macros::DLME do
     end
   end
   let(:instance) { klass.new }
+
+  describe '#default' do
+    it 'returns a Proc' do
+      expect(instance.default('Untitled', 'بدون عنوان')).to be_a(Proc)
+    end
+
+    context 'with no values in accumulator' do
+      it 'replaces accumulator with default value' do
+        accumulator_original = []
+        callable = instance.default('Untitled', 'بدون عنوان')
+        expect(callable.call(nil, accumulator_original)).to eq(
+          [{ language: 'en', values: ['Untitled'] }, { language: 'ar-Arab', values: ['بدون عنوان'] }]
+        )
+      end
+    end
+  end
 
   describe '#lang' do
     context 'with bogus language string' do
@@ -28,7 +53,7 @@ RSpec.describe Macros::DLME do
       accumulator_original = %w[value1 value2 value3]
       accumulator = accumulator_original.dup
       callable = instance.lang('en')
-      expect(callable.call(nil, accumulator, nil)).to eq([{ language: 'en', values: accumulator_original }])
+      expect(callable.call(nil, accumulator, nil)).to eq([language: 'en', values: accumulator_original])
     end
 
     context 'with no values in accumulator' do
@@ -37,6 +62,93 @@ RSpec.describe Macros::DLME do
         callable = instance.lang('en')
         expect(callable.call(nil, accumulator, nil)).to eq nil
       end
+    end
+  end
+
+  describe '#truncate' do
+    it 'returns a String' do
+      expect(instance.truncate('Euchologion ad usum Melchitarum')).to be_a(String)
+    end
+
+    context 'when extracted string longer than 100 charachters' do
+      it 'truncates string on first white space after character 100, adds ellipsis' do
+        arabic_string = 'تتعلق المراسلات وأوراق أخرى بزيارات قامت بها شخصيات أوروبية وأمريكية إلى '\
+        'المملكة العربية السعودية، وتحديدًا إلى الرياض:زيارة في سنة ١٩٣٧قام بها '\
+        'المقدم هارولد ريتشارد باتريك ديكسون، الوكيل السياسي السابق في الكويت'
+        latin_string = 'Euchologion ad usum Melchitarum, partim arabice partim syriace, cum titulis et rubricis plerumque
+        mere arabicis, prinicpio et fine mutilum. Codicem meorat Cyrillus Charon (Korolevski) apud Χρυσοστομικά,
+        Romae, 1908, pp. 673 sq. Cf. cod. Vat. ar. 54 ; iisdem notis utimur ac in codice laudato.'
+        expect(instance.truncate(arabic_string)).to eq('تتعلق المراسلات وأوراق أخرى بزيارات قامت بها شخصيات '\
+          'أوروبية وأمريكية إلى المملكة العربية السعودية...')
+        expect(instance.truncate(latin_string)).to eq('Euchologion ad usum Melchitarum, partim arabice partim syriace, '\
+          'cum titulis et rubricis plerumque...')
+      end
+    end
+
+    context 'when extracted string shorter than 100 charachters' do
+      it 'returns string without change' do
+        arabic_string = 'تتعلق المراسلات وأوراق أخرى'
+        latin_string = 'Euchologion ad usum Melchitarum'
+        expect(instance.truncate(arabic_string)).to eq('تتعلق المراسلات وأوراق أخرى')
+        expect(instance.truncate(latin_string)).to eq('Euchologion ad usum Melchitarum')
+      end
+    end
+  end
+
+  describe '#xpath_title_or_desc' do
+    let(:title_only_record) do
+      <<-XML
+        <record>
+          <metadata>
+            <title>Qur'an</title>
+          </metadata>
+        </record>
+      XML
+    end
+    let(:title_only) { Nokogiri::XML.parse(title_only_record) }
+    let(:desc_only_record) do
+      <<-XML
+        <record>
+          <metadata>
+            <description>Arabic Manuscript</descritpion>
+          </metadata>
+        </record>
+      XML
+    end
+    let(:desc_only) { Nokogiri::XML.parse(desc_only_record) }
+    let(:neither_record) do
+      <<-XML
+        <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <metadata>
+            <dc
+              xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+              xmlns:dc="http://purl.org/dc/elements/1.1/"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+              <dc:type>Manuscripts</dc:type>
+            <dc>
+          </metadata>
+        </record>
+      XML
+    end
+    let(:neither) { Nokogiri::XML.parse(neither_record) }
+
+    before do
+      indexer.instance_eval do
+        to_field 'cho_title', xpath_title_or_desc('/record/metadata/title', '/record/metadata/description')
+      end
+    end
+
+    it 'has title provided a value' do
+      expect(indexer.map_record(title_only)).to eq('cho_title' => ["Qur'an"])
+    end
+
+    it 'has description but no title' do
+      expect(indexer.map_record(desc_only)).to eq('cho_title' => ['Arabic Manuscript'])
+    end
+
+    it 'has neither title nor description' do
+      expect(indexer.map_record(neither)).to eq({})
     end
   end
 end

--- a/traject_configs/aub_aco_config.rb
+++ b/traject_configs/aub_aco_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Cho Required
-to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title", "#{OAI_PREFIX}/dc:description[1]"), arabic_or_und_latn, default('Untitled', 'بدون عنوان')
+to_field 'cho_title', xpath_title_or_desc("#{PREFIX}/dc:title", "#{PREFIX}/dc:description[1]"), arabic_or_und_latn, default('Untitled', 'بدون عنوان')
 
 # Cho Other
 to_field 'cho_contributor', extract_oai('dc:contributor'),

--- a/traject_configs/aub_aco_config.rb
+++ b/traject_configs/aub_aco_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Cho Required
-to_field 'cho_title', extract_oai('dc:title'), strip, default('Untitled'), lang('en')
+to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title", "#{OAI_PREFIX}/dc:description[1]"), arabic_or_und_latn, default('Untitled', 'بدون عنوان')
 
 # Cho Other
 to_field 'cho_contributor', extract_oai('dc:contributor'),

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -2,6 +2,7 @@
 
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/aub'
 require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
@@ -13,6 +14,7 @@ require 'macros/timestamp'
 require 'macros/version'
 require 'traject_plus'
 
+extend Macros::AUB
 extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing

--- a/traject_configs/aub_common_config.rb
+++ b/traject_configs/aub_common_config.rb
@@ -7,6 +7,7 @@ require 'macros/collection'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/oai'
@@ -19,6 +20,7 @@ extend Macros::Collection
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
 extend Macros::OAI

--- a/traject_configs/cambridge_config.rb
+++ b/traject_configs/cambridge_config.rb
@@ -26,11 +26,6 @@ extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Tei
 extend TrajectPlus::Macros::Xml
 
-settings do
-  provide 'reader_class_name', 'TrajectPlus::XmlReader'
-  provide 'writer_class_name', 'DlmeJsonResourceWriter'
-end
-
 # Shortcut variables
 MS_CONTENTS = 'tei:msContents'
 MS_DESC = '//tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'
@@ -41,6 +36,11 @@ OBJ_DESC = 'tei:physDesc/tei:objectDesc'
 PROFILE_DESC = '//tei:teiHeader/tei:profileDesc/tei:textClass'
 PUB_STMT = '//tei:teiHeader/tei:fileDesc/tei:publicationStmt'
 SUPPORT_DESC = 'tei:supportDesc[@material="paper"]'
+
+settings do
+  provide 'reader_class_name', 'TrajectPlus::XmlReader'
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+end
 
 each_record do |record, context|
   context.clipboard[:id] = extract_record_id(record)
@@ -57,7 +57,7 @@ to_field 'id', lambda { |_record, accumulator, context|
   bare_id = default_identifier(context)
   accumulator << identifier_with_prefix(context, bare_id)
 }
-to_field 'cho_title', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[1]"), strip, default('Untitled'), lang('en')
+to_field 'cho_title', xpath_title_or_desc("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:title[1]", "#{MS_DESC}/#{MS_CONTENTS}/tei:summary[1]"), lang('en'), default('Untitled', 'بدون عنوان')
 
 # Cho other
 to_field 'cho_creator', extract_tei("#{MS_DESC}/#{MS_CONTENTS}/#{MS_ITEM}/tei:author"), strip, lang('en')

--- a/traject_configs/manchester_genizah_config.rb
+++ b/traject_configs/manchester_genizah_config.rb
@@ -44,8 +44,7 @@ to_field 'dlme_source_file', path_to_file
 
 # CHO Required
 to_field 'id', extract_oai_identifier, strip
-to_field 'cho_title', extract_oai('dc:title'), strip, default('Untitled'), lang('en')
-to_field 'cho_title', extract_oai('dc:title'), strip, default('بدون عنوان'), lang('ar-Arab')
+to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title", "#{OAI_PREFIX}/dc:description"), lang('en'), default('Untitled', 'بدون عنوان')
 
 # CHO Other
 to_field 'cho_creator', extract_oai('dc:creator'), strip, lang('en')

--- a/traject_configs/manchester_hebraica_config.rb
+++ b/traject_configs/manchester_hebraica_config.rb
@@ -44,7 +44,7 @@ to_field 'dlme_source_file', path_to_file
 
 # CHO Required
 to_field 'id', extract_oai_identifier, strip
-to_field 'cho_title', extract_oai('dc:title'), strip, default('Untitled'), lang('en')
+to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title", "#{OAI_PREFIX}/dc:description"), lang('en'), default('Untitled', 'بدون عنوان')
 
 # CHO Other
 to_field 'cho_creator', extract_oai('dc:creator'), strip, lang('en')

--- a/traject_configs/manchester_nashriyah_config.rb
+++ b/traject_configs/manchester_nashriyah_config.rb
@@ -44,8 +44,8 @@ to_field 'dlme_source_file', path_to_file
 
 # CHO Required
 to_field 'id', extract_oai_identifier, strip
-to_field 'cho_title', extract_oai('dc:title'), strip, first_only, lang('fa-Arab')
-to_field 'cho_title', extract_oai('dc:title'), strip, last, lang('en')
+to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title[1]", "#{OAI_PREFIX}/dc:description[1]"), lang('fa-Arab'), default('Untitled', 'بدون عنوان')
+to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title[last()]", "#{OAI_PREFIX}/dc:description[last()]"), lang('fa-Latn')
 
 # CHO Other
 to_field 'cho_creator', extract_oai('dc:creator'), strip, lang('fa-Arab')

--- a/traject_configs/manchester_papyri_config.rb
+++ b/traject_configs/manchester_papyri_config.rb
@@ -44,7 +44,7 @@ to_field 'dlme_source_file', path_to_file
 
 # CHO Required
 to_field 'id', extract_oai_identifier, strip
-to_field 'cho_title', extract_oai('dc:title'), strip, default('Untitled'), lang('en')
+to_field 'cho_title', xpath_title_or_desc("#{OAI_PREFIX}/dc:title", "#{OAI_PREFIX}/dc:description"), lang('en'), default('Untitled', 'بدون عنوان')
 
 # CHO Other
 to_field 'cho_creator', extract_oai('dc:creator'), strip, lang('en')

--- a/traject_configs/vatican_config.rb
+++ b/traject_configs/vatican_config.rb
@@ -11,6 +11,7 @@ require 'macros/normalize_language'
 require 'macros/path_to_file'
 require 'macros/tei'
 require 'macros/timestamp'
+require 'macros/vatican'
 require 'macros/version'
 require 'traject_plus'
 
@@ -23,6 +24,7 @@ extend Macros::NormalizeLanguage
 extend Macros::PathToFile
 extend Macros::Tei
 extend Macros::Timestamp
+extend Macros::Vatican
 extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Tei
@@ -36,16 +38,13 @@ end
 # File path
 to_field 'dlme_source_file', path_to_file
 
-# Shortcut variables
-MS_DESC = '//teiHeader/fileDesc/sourceDesc/msDescription'
-
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # Cho Required
 to_field 'id', extract_tei("#{MS_DESC}/msIdentifier/idno")
-to_field 'cho_title', extract_tei('//fileDesc/titleStmt/title'), default('Untitled'), strip, lang('en')
+to_field 'cho_title', xpath_title_or_desc('//fileDesc/titleStmt/title', "#{MS_DESC}/msPart/msContents/overview"), lang('und-Latn'), default('Untitled', 'بدون عنوان')
 
 # Cho other
 to_field 'cho_creator', extract_tei('//fileDesc/titleStmt/author/alias/authorityAuthor'), strip, lang('en')


### PR DESCRIPTION
## Why was this change made?

cho_title is a required field, but several datasets have records without titles. The `default` macro in traject needed to be updated to work with our hashing. A new strategy of passing truncated descriptions in the case that no titles are found in the record has been recently adopted. 

## How was this change tested?

Local transformations and analysis scripts

## Which documentation and/or configurations were updated?

n/a

