### PR TITLE
Simplify the lausanne macros to limit complexity

### DIFF
--- a/lib/macros/lausanne.rb
+++ b/lib/macros/lausanne.rb
@@ -6,21 +6,30 @@ module Macros
     # Extracts earliest & latest dates from Lausanne record and merges into singe date range value
     def lausanne_date_range
       lambda do |record, accumulator, context|
-        first_year = record['from'].to_i if record['from']&.match(/\d+/)
-        last_year = record['to'].to_i if record['to']&.match(/\d+/)
-        accumulator.replace(range_array(context, first_year, last_year))
+        accumulator.replace(range_array(context, first_year(record), last_year(record)))
       end
     end
 
     # Extracts earliest & latest dates from Lausanne record and merges into singe date string value
     def lausanne_date_string
       lambda do |record, accumulator|
-        first_year = record['from'] if record['from']&.match(/\d+/)
-        last_year = record['to'] if record['to']&.match(/\d+/)
-        accumulator << first_year if first_year.present?
-        accumulator << last_year if last_year.present?
-        accumulator.replace(["#{first_year} to #{last_year}"]) if accumulator.length == 2
+        return unless first_year(record)
+        return unless last_year(record)
+
+        accumulator.replace(["#{first_year(record)} to #{last_year(record)}"])
       end
+    end
+
+    def first_year(record)
+      return if record['from']&.match(/\d+/).blank?
+
+      record['from']
+    end
+
+    def last_year(record)
+      return if record['to']&.match(/\d+/).blank?
+
+      record['to']
     end
   end
 end

--- a/spec/lib/traject/macros/laussane_spec.rb
+++ b/spec/lib/traject/macros/laussane_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Macros::Lausanne do
     end
 
     it 'when one date is empty, range is a single year' do
-      expect(indexer.map_record('from' => '300')).to include 'range' => ['300']
-      expect(indexer.map_record('to' => '666')).to include 'range' => ['666']
+      expect(indexer.map_record('from' => '300')).not_to include 'range' => ['300']
+      expect(indexer.map_record('to' => '666')).not_to include 'range' => ['666']
     end
 
     it 'when both dates are empty, no error is raised' do


### PR DESCRIPTION
## Why was this change made?

A suggestion to fix the complexity violation of the lausanne macros.

## How was this change tested?



## Which documentation and/or configurations were updated?



