### PR TITLE
add a shared_example for validating translation maps

### DIFF
--- a/lib/translation_maps/edm_type_from_has_type.yaml
+++ b/lib/translation_maps/edm_type_from_has_type.yaml
@@ -1,5 +1,5 @@
 # Basic mapping from has_type_values to edm_type_values
-3d: 3d
+3d: 3D
 adornments: Object
 amulets: Object
 archaeological sites: Image

--- a/lib/translation_maps/spatial_ar_from_en.yaml
+++ b/lib/translation_maps/spatial_ar_from_en.yaml
@@ -35,4 +35,5 @@ Ur (Tell Muqayyar): أور (تل مقير)
 Ur (Tell Muqayyar)?: أور (تل مقير)؟
 Uruk (Warka): أوروك (الوركاء)
 uruk (warka)?: أوروك (الوركاء)؟
+Uruk (Warka)?: أوروك (الوركاء)؟
 Uruk Larsa: أوروك لارسا

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+RSpec.shared_examples 'a valid translation map' do |lang_map_name, contributor_map_filename|
+  YAML.load_file(contributor_map_filename).each do |_key, values|
+    Array(values).each do |literal_value| # ensure values is an array (since values can be a string OR an array of strings)
+      context "with a value from #{contributor_map_filename}" do
+        let(:translation) do
+          indexer = Traject::Indexer.new
+          indexer.configure do
+            to_field 'cho_to_field', literal(literal_value), translation_map(lang_map_name)
+          end
+          indexer.map_record(nil)['cho_to_field']
+        end
+
+        it "translates #{literal_value} using #{lang_map_name}" do
+          expect(translation).not_to be_nil
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSpec/DescribeClass this tests config consistency, not a class
+  # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/738
+  # it_behaves_like 'a valid translation map', 'temporal_ar_from_en', 'lib/translation_maps/temporal_from_contributor.yaml'
+
+  it_behaves_like 'a valid translation map', 'spatial_ar_from_en', 'lib/translation_maps/spatial_from_contributor.yaml'
+end

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -29,4 +29,8 @@ RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSp
   # it_behaves_like 'a valid translation map', 'temporal_ar_from_en', 'lib/translation_maps/temporal_from_contributor.yaml'
 
   it_behaves_like 'a valid translation map', 'spatial_ar_from_en', 'lib/translation_maps/spatial_from_contributor.yaml'
+
+  # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/740
+  it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_fr.yaml'
+  # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_fr.yaml'
 end

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -2,6 +2,8 @@
 
 require 'yaml'
 
+# expect that all the values listed in contributor_map_filename are translatable using the
+# mapping config specified by lang_map_name
 RSpec.shared_examples 'a valid translation map' do |lang_map_name, contributor_map_filename|
   YAML.load_file(contributor_map_filename).each do |_key, values|
     Array(values).each do |literal_value| # ensure values is an array (since values can be a string OR an array of strings)

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -41,4 +41,6 @@ RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSp
   # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/742
   it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_tr.yaml'
   # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_tr.yaml'
+
+  it_behaves_like 'a valid translation map', 'edm_type_ar_from_en', 'lib/translation_maps/edm_type_from_has_type.yaml'
 end

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -33,4 +33,8 @@ RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSp
   # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/740
   it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_fr.yaml'
   # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_fr.yaml'
+
+  # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/741
+  it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_lausanne.yaml'
+  # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_lausanne.yaml'
 end

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -43,4 +43,7 @@ RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSp
   # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_tr.yaml'
 
   it_behaves_like 'a valid translation map', 'edm_type_ar_from_en', 'lib/translation_maps/edm_type_from_has_type.yaml'
+
+  # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/743
+  # it_behaves_like 'a valid translation map', 'getty_aat_material_ar_from_en', 'lib/translation_maps/getty_aat_material_from_contributor.yaml'
 end

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -37,4 +37,8 @@ RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSp
   # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/741
   it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_lausanne.yaml'
   # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_lausanne.yaml'
+
+  # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/742
+  it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_tr.yaml'
+  # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_tr.yaml'
 end

--- a/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
+++ b/spec/lib/translation_maps/validate_contributor_translation_maps_spec.rb
@@ -46,4 +46,8 @@ RSpec.describe 'contributor translation maps are valid' do # rubocop:disable RSp
 
   # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/743
   # it_behaves_like 'a valid translation map', 'getty_aat_material_ar_from_en', 'lib/translation_maps/getty_aat_material_from_contributor.yaml'
+
+  # TODO: un-skip once we have the translations that will make it pass. see https://github.com/sul-dlss/dlme-transform/issues/744
+  it_behaves_like 'a valid translation map', 'has_type_ar_from_en', 'lib/translation_maps/has_type_from_contributor.yaml'
+  # it_behaves_like 'a valid translation map', 'edm_type_from_has_type', 'lib/translation_maps/has_type_from_contributor.yaml'
 end


### PR DESCRIPTION
## Why was this change made?

* use it to test a couple sets of mappings, including one skipped for now due to known lack of translations
* add a missing translation caught by the tests

closes #722 
closes #723
closes #724 
closes #725 
closes #726 
closes #727 
closes #728 
closes #729

see also #738
see also #740
see also #741 
see also #742
see also #743 
see also #744

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

translation config

