### PR TITLE
 Remove generic cho_has_type value when specific value present

### DIFF
--- a/lib/macros/normalize_type.rb
+++ b/lib/macros/normalize_type.rb
@@ -29,6 +29,10 @@ module Macros
                                Traject::TranslationMap.new(spec)
                              end.reduce(:merge)
         translation_map.translate_array!(accumulator)
+
+        # if there are type values more specific than "[O|o]ther *", keep only those more specific values
+        acc_minus_generic_types = accumulator.reject { |str| str.start_with?(/[O|o]ther /) }
+        accumulator.replace(acc_minus_generic_types) unless acc_minus_generic_types.empty?
       end
     end
   end

--- a/lib/macros/normalize_type.rb
+++ b/lib/macros/normalize_type.rb
@@ -21,11 +21,13 @@ module Macros
     # @example
     #   normalize_language => lambda { ... }
     # @return [Proc] a proc that traject can call for each record
-    def normalize_has_type
+    def normalize_has_type # rubocop:disable Metrics/MethodLength
       lambda do |_record, accumulator|
         accumulator.map!(&:downcase)
         translation_map = %w[has_type_from_contributor
-                             has_type_from_fr has_type_from_lausanne has_type_from_tr].map do |spec|
+                             has_type_from_fr
+                             has_type_from_lausanne
+                             has_type_from_tr].map do |spec|
                                Traject::TranslationMap.new(spec)
                              end.reduce(:merge)
         translation_map.translate_array!(accumulator)

--- a/spec/lib/traject/macros/harvard_ihp_spec.rb
+++ b/spec/lib/traject/macros/harvard_ihp_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Macros::HarvardIHP do
     end
   end
 
-  let(:raw_val_lambda) do
-    lambda do |record, accumulator|
-      accumulator << record[:raw]
-    end
-  end
-
   describe '#ihp_date_range' do
     let(:record) do
       <<-XML

--- a/spec/lib/traject/macros/harvard_scw_spec.rb
+++ b/spec/lib/traject/macros/harvard_scw_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Macros::HarvardSCW do
     end
   end
 
-  let(:raw_val_lambda) do
-    lambda do |record, accumulator|
-      accumulator << record[:raw]
-    end
-  end
-
   describe '#scw_has_type' do
     let(:record) do
       <<-XML

--- a/spec/lib/traject/macros/laussane_spec.rb
+++ b/spec/lib/traject/macros/laussane_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Macros::Lausanne do
     end
   end
 
-  let(:raw_val_lambda) do
-    lambda do |record, accumulafromr|
-      accumulafromr << record[:raw]
-    end
-  end
-
   describe '#lausanne_date_string' do
     before do
       indexer.instance_eval do

--- a/spec/lib/traject/macros/manchester_spec.rb
+++ b/spec/lib/traject/macros/manchester_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Macros::Manchester do
     end
   end
 
-  let(:raw_val_lambda) do
-    lambda do |record, accumulator|
-      accumulator << record[:raw]
-    end
-  end
-
   describe '#manchester_solar_hijri_range' do
     before do
       indexer.instance_eval do

--- a/spec/lib/traject/macros/normalize_type_spec.rb
+++ b/spec/lib/traject/macros/normalize_type_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'macros/normalize_type'
+
+RSpec.describe Macros::NormalizeType do
+  subject(:indexer) do
+    Traject::Indexer.new.tap do |indexer|
+      indexer.instance_eval do
+        extend TrajectPlus::Macros
+        extend Macros::NormalizeType # rubocop:disable RSpec/DescribedClass described_class doesn't seem to work from in the instance_eval
+      end
+    end
+  end
+
+  describe '#normalize_has_type' do
+    let(:record) do
+      ['amulet fragment', 'animal bone', 'archival file', 'spindle', 'die', 'tetrapod vessel']
+    end
+    let(:json_record) { record.to_json }
+
+    before do
+      json_list_merge_lambda = lambda do |record, accumulator|
+        accumulator.concat Array(JSON.parse(record))
+      end
+
+      indexer.instance_eval do
+        to_field 'cho_has_type', json_list_merge_lambda, normalize_has_type
+      end
+    end
+
+    it "removes elements that match '[O|o]ther *' if there are more specific elements" do
+      expect(indexer.map_record(json_record)).to eq 'cho_has_type' => ['Amulets', 'Tools & Equipment', 'Recreational Artifacts', 'Containers']
+    end
+
+    context 'when accumulator contains no specific types' do
+      let(:record) { ['animal bone', 'painting & drawing', 'gravür'] }
+
+      it 'passes through the types that are available' do
+        expect(indexer.map_record(json_record)).to eq 'cho_has_type' => ['Other Objects', 'Other Images', 'Other Images']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

closes #701

also, some opportunistic touchups in the second commit (discovered the unused `let` vars while looking for testing patterns i could copy).

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a

