### PR TITLE
Do not insert bad data when a iiif manifest is not available for QNL

### DIFF
--- a/traject_configs/qnl_config.rb
+++ b/traject_configs/qnl_config.rb
@@ -148,12 +148,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
                                     'wr_has_service' => iiif_thumbnail_service(iiif_json),
                                     'wr_id' => literal(iiif_thumbnail_id(iiif_json)),
                                     'wr_is_referenced_by' => literal(context.clipboard[:manifest]))
-  else
-    accumulator << transform_values(context,
-                                    'wr_edm_rights' => [extract_qnl_en('mods:accessCondition'), strip, translation_map('edm_rights')],
-                                    'wr_format' => literal('image/jpeg'),
-                                    'wr_id' => literal(context.clipboard[:id]),
-                                    'wr_is_referenced_by' => literal(context.clipboard[:manifest]))
   end
 end
 to_field 'agg_provider', provider, lang('en')


### PR DESCRIPTION
## Why was this change made?

Fixes #759 

QNL is the only collection where we were inserting bad data into the `agg_preview` hash conditionally if a iiif manifest is not available. By inserting non-urls into `agg_preview.wr_id` blacklight broke attempting to render bad URLs, this resolves that.

## How was this change tested?

Ran in dev, manual analysis, and existing integration tests.

## Which documentation and/or configurations were updated?



