### PR TITLE
silence stdout and stderr during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,13 @@ repo.
 ```shell
 $ bundle exec rake
 ```
+
+By default, test setup squelches any output that the code being tested sends to `STDOUT` and `STDERR`.  `DLME::Utils.logger` output is still printed.  This is because test output can be very verbose, especially when using all of `dlme-metadata` in the `data` dir, as is done for CI.  The default behavior can make debugging failing tests easier, especially in CircleCI, where there's a size limit on browser display of test output.
+
+If `STDOUT` or `STDERR` would be useful, output to each from the tests can be allowed by using env vars (independently or together).
+```sh
+$ be rspec # default, just the logger output
+$ NO_SQUELCH_STDERR=1 be rspec # allow tests to print to STDERR (plus logger output)
+$ NO_SQUELCH_STDOUT=1 be rspec # allow tests to print to STDOUT (plus logger output), can be very noisy if run over all metadata
+$ NO_SQUELCH_STDERR=1 NO_SQUELCH_STDOUT=1 be rspec # everything
+```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,11 +100,11 @@ RSpec.configure do |config|
   original_stdout = $stdout
   config.before(:all) do
     # Redirect stderr and stdout
-    $stderr = File.open(File::NULL, 'w')
-    $stdout = File.open(File::NULL, 'w')
+    $stderr = File.open(File::NULL, 'w') unless ENV['NO_SQUELCH_STDERR']
+    $stdout = File.open(File::NULL, 'w') unless ENV['NO_SQUELCH_STDOUT']
   end
   config.after(:all) do
-    $stderr = original_stderr
-    $stdout = original_stdout
+    $stderr = original_stderr unless ENV['NO_SQUELCH_STDERR']
+    $stdout = original_stdout unless ENV['NO_SQUELCH_STDOUT']
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,4 +90,21 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # stderr and stdout are pretty noisy in this app.  silencing them
+  # does not affect test behavior, but it does make it easier to pore
+  # over output from failed tests, especially in CI, where the amount of
+  # output can overrun CircleCI's limit for in-browser display.
+  # Note also that this shouldn't squelch output from ::DLME::Utils.logger.
+  original_stderr = $stderr
+  original_stdout = $stdout
+  config.before(:all) do
+    # Redirect stderr and stdout
+    $stderr = File.open(File::NULL, 'w')
+    $stdout = File.open(File::NULL, 'w')
+  end
+  config.after(:all) do
+    $stderr = original_stderr
+    $stdout = original_stdout
+  end
 end


### PR DESCRIPTION
## Why was this change made?

makes it easier to see what's breaking the build in CI, where stdout and stderr output can easily overrun CircleCI's limit for in-browser output display.

extracted from #761, since that's taking a little while to figure out, and this is generally useful.

## How was this change tested?

* ran unit tests locally
  * confirmed that `STDOUT` and `STDERR` are both squelched by default, and that logger output is always shown
  * confirmed that `NO_SQUELCH_STDERR` flag works
  * confirmed that `NO_SQUELCH_STDOUT` flag works
* CI

## Which documentation and/or configurations were updated?

`spec_helper.rb`, `README.md`