### PR TITLE
Update the output filename to include data_path for versioning and...

### DIFF
--- a/invoke.sh
+++ b/invoke.sh
@@ -10,10 +10,11 @@ if [ $SKIP_FETCH_DATA != "true" ]; then
   rm main.zip
 fi
 
-UUID=$(uuidgen)
-OUTPUT_FILENAME="output-$UUID.ndjson"
+DATA_DIR=$@
+DATA_DIR=${DATA_DIR//\//-}
+OUTPUT_FILENAME="output-$DATA_DIR.ndjson"
 OUTPUT_FILEPATH="output/$OUTPUT_FILENAME"
-SUMMARY_FILEPATH="output/summary-$UUID.json"
+SUMMARY_FILEPATH="output/summary-$DATA_DIR.json"
 
 set +e
 exe/transform --summary-filepath $SUMMARY_FILEPATH --data-dir $@ | tee $OUTPUT_FILEPATH


### PR DESCRIPTION
... improved user experience

## Why was this change made?

In order to provide a better curatorial user experience, we need to be able to clear out and find transformed data (and associate it with a collection). This is complicated by the uuid based file naming as it limits versioning abilities in S3 and leads to excessive storage of older (unusable) transformations.

This is part of https://github.com/sul-dlss/dlme/issues/1153

New filename pattern: `https://.../dlme-metadata-dev/output-stanford.ndjson`

## How was this change tested?

N/A


## Which documentation and/or configurations were updated?



