### PR TITLE
Remove Honeybadger initialization warning from output

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,2 @@
+logging:
+  level: "WARN"


### PR DESCRIPTION
## Why was this change made?

By default, honeybadger outputs an initialization message that gets inserted into our output. This causes a bug with parsing JSON later in the ingestion process. By setting the honeybadger log level to warn (per: https://github.com/honeybadger-io/honeybadger-ruby/issues/296) that message no longer appears in our output.

## How was this change tested?



## Which documentation and/or configurations were updated?



