### PR TITLE
remove html warning, fixes #785

### DIFF
--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -18,7 +18,7 @@ module Macros
       config_file_path = caller_locations(1, 1).first.path
 
       lambda do |_record, context| # rubocop:disable  Metrics/BlockLength
-        context.output_hash.select { |key, _values| fields.include?(key) }.each do |key, values| # rubocop:disable  Metrics/BlockLength
+        context.output_hash.select { |key, _values| fields.include?(key) }.each do |key, values|
           result = Hash.new { [] }
           log_msg_template = "#{config_file_path}: key=#{key}; %<msg>s.  Check source data and/or traject config for errors."
 

--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -33,7 +33,6 @@ module Macros
               sub_values = value[:values].reject(&:nil?).reject(&:empty?)
               html_cleaned = html_check(sub_values)
               unless html_cleaned == sub_values
-                ::DLME::Utils.logger.warn("#{config_file_path}: key=#{key} contains HTML")
                 sub_values = html_cleaned
               end
               result[value[:language]] += sub_values.uniq.tap do |unique_sub_values|

--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -32,9 +32,7 @@ module Macros
             when Hash
               sub_values = value[:values].reject(&:nil?).reject(&:empty?)
               html_cleaned = html_check(sub_values)
-              unless html_cleaned == sub_values
-                sub_values = html_cleaned
-              end
+              sub_values = html_cleaned
               result[value[:language]] += sub_values.uniq.tap do |unique_sub_values|
                 unless unique_sub_values.length == sub_values.length # rubocop:disable Style/IfUnlessModifier 2 lines good, one line bad
                   ::DLME::Utils.logger.warn(format(log_msg_template, { msg: "sub_values=#{sub_values}; sub_values array contains duplicates" }))

--- a/spec/lib/traject/macros/each_record_spec.rb
+++ b/spec/lib/traject/macros/each_record_spec.rb
@@ -57,19 +57,6 @@ RSpec.describe Macros::EachRecord do
           expect(::DLME::Utils.logger).to have_received(:warn).with(a_string_matching(err_msg))
         end
       end
-
-      context 'when context has html tags' do
-        before do
-          mock_context.output_hash = { 'cho_title' => [{ language: 'en', values: ['<p>title1</p>', 'title2'] }] }
-          allow(::DLME::Utils.logger).to receive(:warn)
-        end
-
-        it 'logs a warning indicating html tags were found' do
-          macro.call(nil, mock_context)
-          err_msg = 'each_record_spec.rb: key=cho_title contains HTML'
-          expect(::DLME::Utils.logger).to have_received(:warn).with(a_string_matching(err_msg))
-        end
-      end
     end
 
     context 'when output hash has hash values for given fields' do


### PR DESCRIPTION
## Why was this change made?

- The HTML warning is very noisy and not needed since we can't change the raw data and there is no way we introduced the HTML during mapping.

## How was this change tested?

- Local rspec

## Which documentation and/or configurations were updated?

n/a

