### PR TITLE
Add option to set DATA_DIR in environment for transform run

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ docker run --rm -v $(pwd)/output:/opt/traject/output \
                 stanford/maps/data/kj751hs0595.mods
 ```
 
+Optionally set the data dir in the environment:
+
+```shell
+docker run --rm -e DATA_PATH=stanford/maps/data/kj751hs0595.mods \
+                -v $(pwd)/output:/opt/traject/output \
+                suldlss/dlme-transform:latest
+```
+
 The output will appear in STDOUT inside the container and be written to
 `/opt/traject/output`. (In this example, `/opt/traject/output` inside the
 container is mounted from `./output` outside the container, which will

--- a/invoke.sh
+++ b/invoke.sh
@@ -10,14 +10,18 @@ if [ $SKIP_FETCH_DATA != "true" ]; then
   rm main.zip
 fi
 
-DATA_DIR=$@
+DATA_PATH=${DATA_PATH:-$@} # Get the data dir from the environment first if it exists.
+DATA_DIR=$DATA_PATH
 DATA_DIR=${DATA_DIR//\//-}
+
+echo "Starting dlme-transform for: ${DATA_PATH}"
+
 OUTPUT_FILENAME="output-$DATA_DIR.ndjson"
 OUTPUT_FILEPATH="output/$OUTPUT_FILENAME"
 SUMMARY_FILEPATH="output/summary-$DATA_DIR.json"
 
 set +e
-exe/transform --summary-filepath $SUMMARY_FILEPATH --data-dir $@ | tee $OUTPUT_FILEPATH
+exe/transform --summary-filepath $SUMMARY_FILEPATH --data-dir $DATA_PATH | tee $OUTPUT_FILEPATH
 
 if [ -n "$PUSH_TO_AWS" ]; then
   echo "Logging into AWS DevelopersRole"
@@ -52,3 +56,5 @@ if [ -n "$SNS_TOPIC_ARN" ]; then
   echo "Sending notification to SNS"
   aws sns publish --topic-arn $SNS_TOPIC_ARN --message file://$SUMMARY_FILEPATH $SNS_ENDPOINT_URL_ARG
 fi
+
+echo "Dlme-transform complete for: ${DATA_PATH}"


### PR DESCRIPTION
## Why was this change made?

This is a small PR to allow for optionally setting the data_dir via the environment. This will enable airflow to trigger the DLME transform task in ECS without the command line parameter. 

## How was this change tested?

Manually


## Which documentation and/or configurations were updated?

README

