### PR TITLE
Gemfile: remove note about simplecov version needs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,5 @@ group :test do
   gem 'rubocop', '~> 1.13.0'
   gem 'rubocop-performance', '~> 1.11.0'
   gem 'rubocop-rspec', '~> 2.3.0'
-  # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
   gem 'simplecov', '~> 0.21'
 end


### PR DESCRIPTION
## Why was this change made?

Note is no longer needed;  version specification is enough.

## How was this change tested?



## Which documentation and/or configurations were updated?



