### PR TITLE
Switch to non-deprecated circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ executors:
     environment:
       IMAGE_NAME: suldlss/dlme-transform
     docker:
-    - image: circleci/buildpack-deps:stretch
+    - image: cimg/base
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.7.1-node
+      - image: cimg/ruby:2.7
     steps:
       - checkout
 


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



