### PR TITLE
use docker image to publish that will work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     environment:
       IMAGE_NAME: suldlss/dlme-transform
     docker:
-    - image: cimg/base
+    - image: cimg/base:stable
 jobs:
   test:
     docker:


### PR DESCRIPTION
## Why was this change made?

basing it on https://github.com/sul-dlss/dlme/pull/1382 -- the "build" circleci "build" failed "building" the docker-image with the new `cimg/base`

## How was this change tested?



## Which documentation and/or configurations were updated?



