### PR TITLE
Use ruby 3.0 image to build and publish the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-      - image: cimg/ruby:2.7
+      - image: cimg/ruby:3.0
     steps:
       - checkout
 


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



