### PR TITLE
Add dlme-metadata-main and main.zip to ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 /output/*
 /data/*
+/dlme-metadata-main
+main.zip

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /data/*
 !/data/.keep
 /tmp/output/*
+/dlme-metadata-main/*
+main.zip
 
 # Rspec files:
 spec/examples.txt


### PR DESCRIPTION
## Why was this change made?

This will help avoid accidentally building test data into the image locally which causes issues when the metadata extraction steps.

## How was this change tested?



## Which documentation and/or configurations were updated?



