### PR TITLE
Refactor docker invoke to fetch data from S3 instead of github

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ You can also do this manually (see below).  You only need the local docker image
 
 ### Build image
 ```shell
-docker build --build-arg VCS_REF=`git rev-parse --short HEAD` \
+docker build --no-cache
+             --build-arg VCS_REF=`git rev-parse --short HEAD` \
              --build-arg VCS_URL=`git config --get remote.origin.url` \
              --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+             --build-arg HONEYBADGER_API_KEY=[INSERT KEY] \
              . -t suldlss/dlme-transform:latest
 ```
 

--- a/invoke.sh
+++ b/invoke.sh
@@ -1,29 +1,6 @@
 #!/bin/sh
 set -e
 
-if [ $SKIP_FETCH_DATA != "true" ]; then
-  echo "Getting github.com/sul-dlss/dlme-metadata"
-  curl -L https://github.com/sul-dlss/dlme-metadata/archive/main.zip > main.zip
-  unzip -q main.zip
-  mkdir -p /opt/traject/data
-  mv dlme-metadata-main/* /opt/traject/data
-  rm main.zip
-fi
-
-DATA_PATH=${DATA_PATH:-$1} # Get the data dir from the environment first if it exists.
-DATA_DIR=$DATA_PATH
-DATA_DIR=${DATA_DIR//\//-}
-DEBUG_FLAG=$2
-
-echo "Starting dlme-transform for: ${DATA_PATH}"
-
-OUTPUT_FILENAME="output-$DATA_DIR.ndjson"
-OUTPUT_FILEPATH="output/$OUTPUT_FILENAME"
-SUMMARY_FILEPATH="output/summary-$DATA_DIR.json"
-
-set +e
-exe/transform --summary-filepath $SUMMARY_FILEPATH --data-dir $DATA_PATH $DEBUG_FLAG | tee $OUTPUT_FILEPATH
-
 if [ -n "$PUSH_TO_AWS" ]; then
   echo "Logging into AWS DevelopersRole"
   temp_role=$(AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
@@ -36,17 +13,39 @@ if [ -n "$PUSH_TO_AWS" ]; then
   export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
 fi
 
+DATA_PATH=${DATA_PATH:-$1} # Get the data dir from the environment first if it exists.
+DATA_DIR=$DATA_PATH
+DATA_DIR=${DATA_DIR//\//-}
+DEBUG_FLAG=$2
+DOWNLOAD_PATH=${DATA_PATH%/*}
+S3_DATA="s3://$S3_BUCKET/source/$DOWNLOAD_PATH"
+
+if [ $SKIP_FETCH_DATA != "true" ]; then  
+  echo "Getting $S3_DATA"
+  mkdir -p /opt/traject/data
+  aws s3 cp $S3_DATA /opt/traject/data/$DOWNLOAD_PATH --recursive --quiet
+fi
+
+echo "Starting dlme-transform for: ${DATA_PATH}"
+
+OUTPUT_FILENAME="output-$DATA_DIR.ndjson"
+OUTPUT_FILEPATH="output/$OUTPUT_FILENAME"
+SUMMARY_FILEPATH="output/summary-$DATA_DIR.json"
+
+set +e
+exe/transform --summary-filepath $SUMMARY_FILEPATH --data-dir $DATA_PATH $DEBUG_FLAG | tee $OUTPUT_FILEPATH
+
 if [ -n "$S3_BUCKET" ]; then
   if [ -n "$S3_ENDPOINT_URL" ]; then
     S3_ENDPOINT_URL_ARG="--endpoint-url=$S3_ENDPOINT_URL"
   fi
 
   echo "Sending to S3"
-  aws s3 cp $OUTPUT_FILEPATH s3://$S3_BUCKET --acl public-read $S3_ENDPOINT_URL_ARG
+  aws s3 cp $OUTPUT_FILEPATH s3://$S3_BUCKET/output/ --acl public-read $S3_ENDPOINT_URL_ARG
 
   # Add url to summary
   mv $SUMMARY_FILEPATH $SUMMARY_FILEPATH.tmp
-  jq ".url = \"$S3_BASE_URL/$S3_BUCKET/$OUTPUT_FILENAME\"" $SUMMARY_FILEPATH.tmp > $SUMMARY_FILEPATH
+  jq ".url = \"$S3_BASE_URL/$S3_BUCKET/output/$OUTPUT_FILENAME\"" $SUMMARY_FILEPATH.tmp > $SUMMARY_FILEPATH
   rm $SUMMARY_FILEPATH.tmp
 fi
 


### PR DESCRIPTION
## Why was this change made?

This refactors the existing docker invoke so that the fetch data step does not download the entire data set as a github zip file, but instead fetches only the required data from S3.

## How was this change tested?



## Which documentation and/or configurations were updated?



