### PR TITLE
Parse CSV output values as arrays

### DIFF
--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -61,12 +61,12 @@
   },
   {
     "trajects": [
-      "aub_aco_config.rb"
+      "aub_aco_config_csv.rb"
     ],
     "paths": [
       "aub/aco"
     ],
-    "extension": ".xml",
+    "extension": ".csv",
     "settings": {
       "agg_provider": "American University of Beirut",
       "agg_provider_country": "Lebanon",
@@ -81,12 +81,12 @@
   },
   {
     "trajects": [
-      "aub_aladab_config.rb"
+      "aub_aladab_config_csv.rb"
     ],
     "paths": [
       "aub/aladab"
     ],
-    "extension": ".xml",
+    "extension": ".csv",
     "settings": {
       "agg_provider": "American University of Beirut",
       "agg_provider_country": "Lebanon",
@@ -101,12 +101,12 @@
   },
   {
     "trajects": [
-      "aub_poha_config.rb"
+      "aub_poha_config_csv.rb"
     ],
     "paths": [
       "aub/poha"
     ],
-    "extension": ".xml",
+    "extension": ".csv",
     "settings": {
       "agg_provider": "American University of Beirut",
       "agg_provider_country": "Lebanon",
@@ -121,12 +121,12 @@
   },
   {
     "trajects": [
-      "aub_postcards_config.rb"
+      "aub_postcards_config_csv.rb"
     ],
     "paths": [
       "aub/postcards"
     ],
-    "extension": ".xml",
+    "extension": ".csv",
     "settings": {
       "agg_provider": "American University of Beirut",
       "agg_provider_country": "Lebanon",
@@ -141,12 +141,12 @@
   },
   {
     "trajects": [
-      "aub_posters_config.rb"
+      "aub_posters_config_csv.rb"
     ],
     "paths": [
       "aub/posters"
     ],
-    "extension": ".xml",
+    "extension": ".csv",
     "settings": {
       "agg_provider": "American University of Beirut",
       "agg_provider_country": "Lebanon",
@@ -161,12 +161,12 @@
   },
   {
     "trajects": [
-      "aub_travelbooks_config.rb"
+      "aub_travelbooks_config_csv.rb"
     ],
     "paths": [
       "aub/travelbooks"
     ],
-    "extension": ".xml",
+    "extension": ".csv",
     "settings": {
       "agg_provider": "American University of Beirut",
       "agg_provider_country": "Lebanon",

--- a/lib/macros/csv.rb
+++ b/lib/macros/csv.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'active_support/inflector' # parameterize method is part of active support
+require 'byebug'
+require 'csv'
 
 module Macros
   # Macros for extracting values from CSV rows
@@ -12,6 +14,18 @@ module Macros
       lambda do |row, accumulator, context|
         identifier = row[header_or_index].to_s.parameterize
         accumulator << identifier_with_prefix(context, identifier) if identifier.present?
+      end
+    end
+
+    # Determine if the value in the given column contains an array of values
+    # return either the original value or the array value parsed into elements
+    def parse_csv
+      lambda do |_row, accumulator|
+        return [] if accumulator.empty?
+        return accumulator unless accumulator.first.match?(/[\[\]]/)
+
+        values = accumulator.first.gsub("', '", "','")
+        accumulator.replace(CSV.parse(values.delete('[]'), liberal_parsing: true, quote_char: "'").first)
       end
     end
   end

--- a/spec/lib/traject/macros/csv_spec.rb
+++ b/spec/lib/traject/macros/csv_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'macros/csv'
+
+RSpec.describe Macros::Csv do
+  let(:klass) do
+    Class.new do
+      include Macros::Csv
+    end
+  end
+
+  let(:instance) { klass.new }
+
+  describe '#parse_csv' do
+    it 'returns a Proc' do
+      expect(instance.parse_csv).to be_a(Proc)
+    end
+
+    context 'with no values in accumulator' do
+      it 'returns the empty accumulator' do
+        accumulator_original = []
+        callable = instance.parse_csv
+        expect(callable.call(nil, accumulator_original)).to eq([])
+      end
+    end
+
+    context 'with a string value in accumulator' do
+      it 'returns the original accumulator' do
+        accumulator_original = ['this is my dummy string']
+        callable = instance.parse_csv
+        expect(callable.call(nil, accumulator_original)).to eq(['this is my dummy string'])
+      end
+    end
+
+    context 'with an array value in accumulator' do
+      it 'returns an array with each element in the accumulator' do
+        accumulator_original = ["['this', 'is', 'my', 'dummy', 'string']"]
+        callable = instance.parse_csv
+        expect(callable.call(nil, accumulator_original)).to eq(['this', 'is', 'my', 'dummy', 'string'])
+      end
+    end
+  end
+end

--- a/traject_configs/aub_aco_config_csv.rb
+++ b/traject_configs/aub_aco_config_csv.rb
@@ -48,29 +48,29 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # Cho Required
-to_field 'id', column('id'), strip
-to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+to_field 'id', column('id'), strip, parse_csv
+to_field 'cho_title', json_title_or('title', 'description'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
 
 # Cho Other
-to_field 'cho_creator', column('creator'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
-to_field 'cho_date', column('date'), strip, lang('en')
-to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
-to_field 'cho_date_range_norm', column('date'), strip, parse_range
-to_field 'cho_dc_rights', column('rights'), lang('en')
-to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_creator', column('creator'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, parse_csv, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_csv, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_csv, parse_range
+to_field 'cho_dc_rights', column('rights'), strip, parse_csv, lang('en')
+to_field 'cho_description', column('description'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
 to_field 'cho_edm_type', literal('Image'), lang('en')
 to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_has_type', literal('Posters'), lang('en')
 to_field 'cho_has_type', literal('Posters'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_identifier', column('identifier'), strip
-to_field 'cho_language', column('language'), split(';'),
+to_field 'cho_identifier', column('identifier'), strip, parse_csv
+to_field 'cho_language', column('language'), strip, parse_csv, split(';'),
          split(','), strip, normalize_language, lang('en')
-to_field 'cho_language', column('language'), split(';'),
+to_field 'cho_language', column('language'), strip, parse_csv, split(';'),
          split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_publisher', column('publisher'), strip, lang('en')
-to_field 'cho_spatial', column('coverage'), lang('en')
-to_field 'cho_subject', column('subject'), strip, lang('en')
-to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_publisher', column('publisher'), strip, parse_csv, lang('en')
+to_field 'cho_spatial', column('coverage'), strip, parse_csv, lang('en')
+to_field 'cho_subject', column('subject'), strip, parse_csv, lang('en')
+to_field 'cho_type', column('type'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -80,17 +80,17 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_dc_rights' => [column('rights')],
+    'wr_dc_rights' => [column('rights'), strip, parse_csv],
     'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
-    'wr_id' => [column('identifier'), strip]
+    'wr_id' => [column('identifier'), strip, parse_csv]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_dc_rights' => [column('rights')],
+    'wr_dc_rights' => [column('rights'), strip, parse_csv],
     'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
-    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/posters/'), append('/thumb.jpg')]
+    'wr_id' => [column('id'), strip, parse_csv, prepend('https://libraries.aub.edu.lb/xtf/data/posters/'), append('/thumb.jpg')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/aub_aco_config_csv.rb
+++ b/traject_configs/aub_aco_config_csv.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/aub'
+require 'macros/collection'
+require 'macros/csv'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::AUB
+extend Macros::Collection
+extend Macros::Csv
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Csv
+
+settings do
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+end
+
+
+to_field 'agg_data_provider_collection', collection
+to_field 'dlme_collection', literal('aub-aco'), translation_map('dlme_collection_from_provider_id'), lang('en')
+to_field 'dlme_collection', literal('aub-aco'), translation_map('dlme_collection_from_provider_id'), translation_map('dlme_collection_ar_from_en'), lang('ar-Arab')
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# Cho Required
+to_field 'id', column('id'), strip
+to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_creator', column('creator'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_range
+to_field 'cho_dc_rights', column('rights'), lang('en')
+to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_edm_type', literal('Image'), lang('en')
+to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Posters'), lang('en')
+to_field 'cho_has_type', literal('Posters'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', column('identifier'), strip
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, lang('en')
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_publisher', column('publisher'), strip, lang('en')
+to_field 'cho_spatial', column('coverage'), lang('en')
+to_field 'cho_subject', column('subject'), strip, lang('en')
+to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('identifier'), strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/posters/'), append('/thumb.jpg')]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_aladab_config_csv.rb
+++ b/traject_configs/aub_aladab_config_csv.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/aub'
+require 'macros/collection'
+require 'macros/csv'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::AUB
+extend Macros::Collection
+extend Macros::Csv
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Csv
+
+settings do
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+end
+
+
+to_field 'agg_data_provider_collection', collection
+to_field 'dlme_collection', literal('aub-aladab'), translation_map('dlme_collection_from_provider_id'), lang('en')
+to_field 'dlme_collection', literal('aub-aladab'), translation_map('dlme_collection_from_provider_id'), translation_map('dlme_collection_ar_from_en'), lang('ar-Arab')
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# Cho Required
+to_field 'id', column('id'), strip
+to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_creator', column('creator'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_range
+to_field 'cho_dc_rights', column('rights'), lang('en')
+to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_edm_type', literal('Image'), lang('en')
+to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Posters'), lang('en')
+to_field 'cho_has_type', literal('Posters'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', column('identifier'), strip
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, lang('en')
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_publisher', column('publisher'), strip, lang('en')
+to_field 'cho_spatial', column('coverage'), lang('en')
+to_field 'cho_subject', column('subject'), strip, lang('en')
+to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('identifier'), strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/posters/'), append('/thumb.jpg')]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_poha_config_csv.rb
+++ b/traject_configs/aub_poha_config_csv.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/aub'
+require 'macros/collection'
+require 'macros/csv'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::AUB
+extend Macros::Collection
+extend Macros::Csv
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Csv
+
+settings do
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+end
+
+
+to_field 'agg_data_provider_collection', collection
+to_field 'dlme_collection', literal('aub-aladab'), translation_map('dlme_collection_from_provider_id'), lang('en')
+to_field 'dlme_collection', literal('aub-aladab'), translation_map('dlme_collection_from_provider_id'), translation_map('dlme_collection_ar_from_en'), lang('ar-Arab')
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# Cho Required
+to_field 'id', column('id'), strip
+to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_creator', column('creator'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_range
+to_field 'cho_dc_rights', column('rights'), lang('en')
+to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_edm_type', literal('Image'), lang('en')
+to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Posters'), lang('en')
+to_field 'cho_has_type', literal('Posters'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', column('identifier'), strip
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, lang('en')
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_publisher', column('publisher'), strip, lang('en')
+to_field 'cho_spatial', column('coverage'), lang('en')
+to_field 'cho_subject', column('subject'), strip, lang('en')
+to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('identifier'), strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/posters/'), append('/thumb.jpg')]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_postcards_config_csv.rb
+++ b/traject_configs/aub_postcards_config_csv.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/aub'
+require 'macros/collection'
+require 'macros/csv'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::AUB
+extend Macros::Collection
+extend Macros::Csv
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Csv
+
+settings do
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+end
+
+
+to_field 'agg_data_provider_collection', collection
+to_field 'dlme_collection', literal('aub-postcards'), translation_map('dlme_collection_from_provider_id'), lang('en')
+to_field 'dlme_collection', literal('aub-postcards'), translation_map('dlme_collection_from_provider_id'), translation_map('dlme_collection_ar_from_en'), lang('ar-Arab')
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# Cho Required
+to_field 'id', column('id'), strip
+to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_contributor', column('contributor'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_range
+to_field 'cho_dc_rights', column('rights'), lang('en')
+to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_edm_type', literal('Image'), lang('en')
+to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Postcards'), lang('en')
+to_field 'cho_has_type', literal('Postcards'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', column('identifier'), strip
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, lang('en')
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_publisher', column('publisher'), strip, lang('en')
+to_field 'cho_subject', column('subject'), strip, lang('en')
+to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('identifier'), strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/postcards/'), append('/thumb.jpg')]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_posters_config_csv.rb
+++ b/traject_configs/aub_posters_config_csv.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/aub'
+require 'macros/collection'
+require 'macros/csv'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::AUB
+extend Macros::Collection
+extend Macros::Csv
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Csv
+
+settings do
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+end
+
+
+to_field 'agg_data_provider_collection', collection
+to_field 'dlme_collection', literal('aub-posters'), translation_map('dlme_collection_from_provider_id'), lang('en')
+to_field 'dlme_collection', literal('aub-posters'), translation_map('dlme_collection_from_provider_id'), translation_map('dlme_collection_ar_from_en'), lang('ar-Arab')
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# Cho Required
+to_field 'id', column('id'), strip
+to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_contributor', column('contributor'),
+         strip, split('.'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_range
+to_field 'cho_dc_rights', column('rights'), lang('en')
+to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_edm_type', literal('Image'), lang('en')
+to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Posters'), lang('en')
+to_field 'cho_has_type', literal('Posters'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', column('identifier'), strip
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, lang('en')
+to_field 'cho_language', column('language'), split(';'),
+         split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_spatial', column('coverage'), lang('en')
+to_field 'cho_subject', column('subject'), strip, lang('en')
+to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('identifier'), strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/posters/'), append('/thumb.jpg')]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/aub_posters_config_csv.rb
+++ b/traject_configs/aub_posters_config_csv.rb
@@ -58,7 +58,7 @@ to_field 'cho_date', column('date'), strip, lang('en')
 to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
 to_field 'cho_date_range_norm', column('date'), strip, parse_range
 to_field 'cho_dc_rights', column('rights'), lang('en')
-to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_description', column('description'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
 to_field 'cho_edm_type', literal('Image'), lang('en')
 to_field 'cho_edm_type', literal('Image'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_has_type', literal('Posters'), lang('en')

--- a/traject_configs/aub_travelbooks_config_csv.rb
+++ b/traject_configs/aub_travelbooks_config_csv.rb
@@ -48,28 +48,28 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # Cho Required
-to_field 'id', column('id'), strip
-to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+to_field 'id', column('id'), strip, parse_csv
+to_field 'cho_title', json_title_or('title', 'description'), parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
 
 # Cho Other
-to_field 'cho_creator', extract_csv_values('creator'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
-to_field 'cho_date', column('date'), strip, lang('en')
-to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
-to_field 'cho_date_range_norm', column('date'), strip, parse_range
-to_field 'cho_dc_rights', column('rights'), lang('en')
-to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_creator', column('creator'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, parse_csv, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_csv, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_csv, parse_range
+to_field 'cho_dc_rights', column('rights'), strip, parse_csv, lang('en')
+to_field 'cho_description', column('description'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_has_type', literal('Books'), lang('en')
 to_field 'cho_has_type', literal('Books'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_identifier', column('identifier'), strip
-# to_field 'cho_language', column('language'), first_only, split(';'),
-#          split(','), strip, normalize_language, lang('en')
-# to_field 'cho_language', column('language'), first_only, split(';'),
-#          split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-# to_field 'cho_publisher', column('publisher'), strip, lang('en')
-# to_field 'cho_subject', column('subject'), strip, lang('en')
-# to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_identifier', column('identifier'), strip, parse_csv
+to_field 'cho_language', column('language'), parse_csv, first_only, split(';'),
+         split(','), strip, normalize_language, lang('en')
+to_field 'cho_language', column('language'), parse_csv, first_only, split(';'),
+         split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_publisher', column('publisher'), strip, parse_csv, lang('en')
+to_field 'cho_subject', column('subject'), strip, parse_csv, lang('en')
+to_field 'cho_type', column('type'), strip, parse_csv, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -79,17 +79,17 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_dc_rights' => [column('rights')],
+    'wr_dc_rights' => [column('rights'), strip, parse_csv],
     'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
-    'wr_id' => [column('identifier'), strip]
+    'wr_id' => [column('identifier'), strip, parse_csv]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_dc_rights' => [column('rights')],
+    'wr_dc_rights' => [column('rights'), strip, parse_csv],
     'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
-    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/ulbooks/'), append('/thumb.jpg')]
+    'wr_id' => [column('id'), strip, parse_csv, prepend('https://libraries.aub.edu.lb/xtf/data/ulbooks/'), append('/thumb.jpg')]
   )
 end
 to_field 'agg_provider', provider, lang('en')

--- a/traject_configs/aub_travelbooks_config_csv.rb
+++ b/traject_configs/aub_travelbooks_config_csv.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/aub'
+require 'macros/collection'
+require 'macros/csv'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::AUB
+extend Macros::Collection
+extend Macros::Csv
+extend Macros::DLME
+extend Macros::DateParsing
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::Csv
+
+settings do
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+end
+
+
+to_field 'agg_data_provider_collection', collection
+to_field 'dlme_collection', literal('aub-travelbooks'), translation_map('dlme_collection_from_provider_id'), lang('en')
+to_field 'dlme_collection', literal('aub-travelbooks'), translation_map('dlme_collection_from_provider_id'), translation_map('dlme_collection_ar_from_en'), lang('ar-Arab')
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# Cho Required
+to_field 'id', column('id'), strip
+to_field 'cho_title', json_title_or('title', 'description'), arabic_script_lang_or_default('ar-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_creator', extract_csv_values('creator'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_date', column('date'), strip, lang('en')
+to_field 'cho_date_range_hijri', column('date'), strip, parse_range, hijri_range
+to_field 'cho_date_range_norm', column('date'), strip, parse_range
+to_field 'cho_dc_rights', column('rights'), lang('en')
+to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+to_field 'cho_edm_type', literal('Text'), lang('en')
+to_field 'cho_edm_type', literal('Text'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', literal('Books'), lang('en')
+to_field 'cho_has_type', literal('Books'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', column('identifier'), strip
+# to_field 'cho_language', column('language'), first_only, split(';'),
+#          split(','), strip, normalize_language, lang('en')
+# to_field 'cho_language', column('language'), first_only, split(';'),
+#          split(','), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+# to_field 'cho_publisher', column('publisher'), strip, lang('en')
+# to_field 'cho_subject', column('subject'), strip, lang('en')
+# to_field 'cho_type', column('type'), arabic_script_lang_or_default('ar-Arab', 'und-Latn')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('identifier'), strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_dc_rights' => [column('rights')],
+    'wr_edm_rights' => [literal('CC BY-ND: https://creativecommons.org/licenses/by-nd/4.0/')],
+    'wr_id' => [column('id'), prepend('https://libraries.aub.edu.lb/xtf/data/ulbooks/'), append('/thumb.jpg')]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet


### PR DESCRIPTION
## Why was this change made?

Airflow CSV output is an array for each column, this needs to be parsed as arrays outside of just the csv columns.


## How was this change tested?


## Which documentation and/or configurations were updated?



