### PR TITLE
guard against walters redirect error

### DIFF
--- a/traject_configs/walters_config.rb
+++ b/traject_configs/walters_config.rb
@@ -88,7 +88,7 @@ to_field 'agg_edm_rights', literal('CC0: https://creativecommons.org/publicdomai
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_edm_rights' => literal('CC0: https://creativecommons.org/publicdomain/zero/1.0/'),
-                                  'wr_id' => [extract_json('.ResourceURL')])
+                                  'wr_id' => [extract_json('.ResourceURL'), gsub('http:', 'https:')])
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,


### PR DESCRIPTION
## Why was this change made?

Walters urls had redirect errors (http://art.thewalters.org/detail/84358 -> https://art.thewalters.orgdetail/84358). This guards against that but also should still work if they update their data.


## How was this change tested?

local transform

## Which documentation and/or configurations were updated?

n/a

