### PR TITLE
Remove agg_preview from penn due to no thumbnail provided

### DIFF
--- a/traject_configs/penn_egyptian_config.rb
+++ b/traject_configs/penn_egyptian_config.rb
@@ -81,10 +81,6 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('url')])
 end
-to_field 'agg_preview' do |_record, accumulator, context|
-  accumulator << transform_values(context,
-                                  'wr_id' => [column('thumbnail'), gsub('collections/assets/1600', 'collections/assets/300')])
-end
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')


### PR DESCRIPTION
## Why was this change made?

@jacobthill in my airflow testing, I found that this transform fails due to the missing thumbnail column. If this is incorrect, please let me know so we can pair on it.


## How was this change tested?



## Which documentation and/or configurations were updated?



