### PR TITLE
Remove duplicate collection configuration

### DIFF
--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -9,13 +9,29 @@
     "extension": ".xml",
     "settings": {
       "agg_provider": "The American Institute for Maghrib Studies",
-      "agg_provider_country": ["Morocco", "Algeria", "Tunisia"],
+      "agg_provider_country": [
+        "Morocco",
+        "Algeria",
+        "Tunisia"
+      ],
       "agg_data_provider": "The American Institute for Maghrib Studies",
-      "agg_data_provider_country": ["Morocco", "Algeria", "Tunisia"],
+      "agg_data_provider_country": [
+        "Morocco",
+        "Algeria",
+        "Tunisia"
+      ],
       "agg_provider_ar": "المعهد الأمريكي لدراسات المغرب",
-      "agg_provider_country_ar": ["تونس" ,"الجزائر" ,"المغرب"],
+      "agg_provider_country_ar": [
+        "تونس",
+        "الجزائر",
+        "المغرب"
+      ],
       "agg_data_provider_ar": "المعهد الأمريكي لدراسات المغرب",
-      "agg_data_provider_country_ar": ["تونس" ,"الجزائر" ,"المغرب"],
+      "agg_data_provider_country_ar": [
+        "تونس",
+        "الجزائر",
+        "المغرب"
+      ],
       "inst_id": "aims"
     }
   },
@@ -601,26 +617,6 @@
   },
   {
     "trajects": [
-      "auc_iiif_university_on_the_square_config.rb"
-    ],
-    "paths": [
-      "auc/iiif/university-on-the-square"
-    ],
-    "extension": ".json",
-    "settings": {
-      "agg_provider": "American University in Cairo",
-      "agg_provider_country": "Egypt",
-      "agg_data_provider": "American University in Cairo",
-      "agg_data_provider_country": "Egypt",
-      "agg_provider_ar": "الجامعة الأمريكية في القاهرة",
-      "agg_provider_country_ar": "مصر",
-      "agg_data_provider_ar": "الجامعة الأمريكية في القاهرة",
-      "agg_data_provider_country_ar": "مصر",
-      "inst_id": "auc"
-    }
-  },
-  {
-    "trajects": [
       "auc_oai_kraus_meyerhof_config.rb"
     ],
     "paths": [
@@ -1006,7 +1002,7 @@
       "inst_id": "harvard"
     }
   },
-   {
+  {
     "trajects": [
       "ifpo_config.rb"
     ],


### PR DESCRIPTION
## Why was this change made?

The configuration for `auc/iiif/university-on-the-square` is currently duplicated. This removes the second instance.

## How was this change tested?



## Which documentation and/or configurations were updated?



