### PR TITLE
Add missing macro to AUB

### DIFF
--- a/traject_configs/aub_aco_config_csv.rb
+++ b/traject_configs/aub_aco_config_csv.rb
@@ -11,6 +11,7 @@ require 'macros/each_record'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -26,6 +27,7 @@ extend Macros::EachRecord
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
@@ -45,6 +47,9 @@ to_field 'agg_data_provider_collection', literal('aub-aco'), translation_map('ag
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', column('id'), strip, parse_csv

--- a/traject_configs/aub_aladab_config_csv.rb
+++ b/traject_configs/aub_aladab_config_csv.rb
@@ -11,6 +11,7 @@ require 'macros/each_record'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -26,6 +27,7 @@ extend Macros::EachRecord
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
@@ -45,6 +47,9 @@ to_field 'agg_data_provider_collection', literal('aub-aladab'), translation_map(
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', column('id'), strip

--- a/traject_configs/aub_poha_config_csv.rb
+++ b/traject_configs/aub_poha_config_csv.rb
@@ -11,6 +11,7 @@ require 'macros/each_record'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -26,6 +27,7 @@ extend Macros::EachRecord
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
@@ -45,6 +47,9 @@ to_field 'agg_data_provider_collection', literal('aub-aladab'), translation_map(
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', column('id'), strip

--- a/traject_configs/aub_postcards_config_csv.rb
+++ b/traject_configs/aub_postcards_config_csv.rb
@@ -11,6 +11,7 @@ require 'macros/each_record'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -26,6 +27,7 @@ extend Macros::EachRecord
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
@@ -45,6 +47,9 @@ to_field 'agg_data_provider_collection', literal('aub-postcards'), translation_m
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', column('id'), strip

--- a/traject_configs/aub_posters_config_csv.rb
+++ b/traject_configs/aub_posters_config_csv.rb
@@ -11,6 +11,7 @@ require 'macros/each_record'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -26,6 +27,7 @@ extend Macros::EachRecord
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
@@ -45,6 +47,9 @@ to_field 'agg_data_provider_collection', literal('aub-posters'), translation_map
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', column('id'), strip

--- a/traject_configs/aub_travelbooks_config_csv.rb
+++ b/traject_configs/aub_travelbooks_config_csv.rb
@@ -11,6 +11,7 @@ require 'macros/each_record'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -26,6 +27,7 @@ extend Macros::EachRecord
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
@@ -45,6 +47,9 @@ to_field 'agg_data_provider_collection', literal('aub-travelbooks'), translation
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', column('id'), strip, parse_csv


### PR DESCRIPTION
## Why was this change made?

This is a follow up to the earlier AUB macro. The `dlme_source_file` is used during reporting, where it was surfaced that this field is missing.


## How was this change tested?



## Which documentation and/or configurations were updated?



