### PR TITLE
Change order of macros on Princeton thumbnail extraction

### DIFF
--- a/traject_configs/princeton.rb
+++ b/traject_configs/princeton.rb
@@ -101,7 +101,7 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
-                                  'wr_id' => [column('thumbnail'), split('/full/'), first_only, parse_csv, strip, append('/full/!400,400/0/default.jpg')],
+                                  'wr_id' => [column('thumbnail'), parse_csv, first_only, split('/full/'), strip, append('/full/!400,400/0/default.jpg')],
                                   'wr_is_referenced_by' => column('id'))
 end
 to_field 'agg_provider', provider, lang('en')


### PR DESCRIPTION
## Why was this change made?

The current order splits the text of the thumbnail data too early causing it not to parse properly. We need to do `parse_csv` first in most cases to convert some strings to arrays.

## How was this change tested?



## Which documentation and/or configurations were updated?



