### PR TITLE
Enable new cops and remove old cops that throw errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.0
+  NewCops: enable
   Exclude:
     - data/**/*
 
@@ -57,8 +58,6 @@ Style/TrailingCommaInHashLiteral:
 Style/WordArray:
   Enabled: false
 
-Gemspec/DateAssignment: # (new in 1.10)
-  Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)
   Enabled: true
 Lint/AmbiguousAssignment: # (new in 1.7)

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ end
 group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
-  gem 'rubocop', '~> 1.13.0'
-  gem 'rubocop-performance', '~> 1.11.0'
-  gem 'rubocop-rspec', '~> 2.3.0'
+  gem 'rubocop'
+  gem 'rubocop-performance'
+  gem 'rubocop-rspec'
   gem 'simplecov', '~> 0.21'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.2)
     jsonpath (1.1.2)
       multi_json
     llhttp-ffi (0.4.0)
@@ -149,13 +150,14 @@ GEM
     rspec-support (3.11.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.13.0)
+    rubocop (1.36.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
@@ -219,9 +221,9 @@ DEPENDENCIES
   rake
   rspec
   rspec_junit_formatter
-  rubocop (~> 1.13.0)
-  rubocop-performance (~> 1.11.0)
-  rubocop-rspec (~> 2.3.0)
+  rubocop
+  rubocop-performance
+  rubocop-rspec
   simplecov (~> 0.21)
   thor (~> 0.20)
   traject_plus (~> 1.3)

--- a/lib/dlme_debug_writer.rb
+++ b/lib/dlme_debug_writer.rb
@@ -15,9 +15,9 @@ class DlmeDebugWriter < Traject::LineWriter
     return JSON.generate(adjusted).unicode_normalize if errors.empty?
 
     raise "Transform produced invalid data.\n\n" \
-      "The errors are: #{errors.messages}}\n\n" \
-      "The data looked like this:\n" \
-      "#{JSON.pretty_generate(adjusted)}"
+          "The errors are: #{errors.messages}}\n\n" \
+          "The data looked like this:\n" \
+          "#{JSON.pretty_generate(adjusted)}"
   end
 
   private

--- a/lib/dlme_json_resource_writer.rb
+++ b/lib/dlme_json_resource_writer.rb
@@ -16,9 +16,9 @@ class DlmeJsonResourceWriter < Traject::LineWriter
     return JSON.generate(adjusted).unicode_normalize if errors.empty?
 
     ::DLME::Utils.logger.error "Transform produced invalid data.\n\n" \
-      "The errors are: #{errors.messages}}\n\n" \
-      "The data looked like this:\n" \
-      "The record id is: #{adjusted['id']}"
+                               "The errors are: #{errors.messages}}\n\n" \
+                               "The data looked like this:\n" \
+                               "The record id is: #{adjusted['id']}"
 
     nil
   end

--- a/lib/macros/cambridge.rb
+++ b/lib/macros/cambridge.rb
@@ -29,7 +29,7 @@ module Macros
     # @param [Nokogiri::Document] record from which to get dimension lists
     # @param [Integer] idx which set of dimensions to stringify
     def height_width_str(record, idx)
-      "#{meausured_object(record)[idx].capitalize}: "\
+      "#{meausured_object(record)[idx].capitalize}: " \
         "(height: #{height(record)[idx]} #{unit(record)[idx]}, width: #{width(record)[idx]} #{unit(record)[idx]})"
     end
 

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -126,7 +126,7 @@ module Macros
     TEI_NS = { tei: 'http://www.tei-c.org/ns/1.0' }.freeze
     TEI_MS_DESC = '//tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc'
     TEI_MS_ORIGIN = 'tei:history/tei:origin'
-    TEI_ORIG_DATE_PATH = "#{TEI_MS_DESC}/#{TEI_MS_ORIGIN}/tei:origDate"
+    TEI_ORIG_DATE_PATH = "#{TEI_MS_DESC}/#{TEI_MS_ORIGIN}/tei:origDate".freeze
 
     # extracts dates from TEI origDate element for Cambridge data
     # Best dates will be in notBefore/notAfter attributes, or from/to attributes
@@ -160,8 +160,8 @@ module Macros
 
     FGDC_NS = { fgdc: 'http://www.fgdc.gov/metadata/fgdc-std-001-1998.dtd' }.freeze
     FGDC_TIMEINFO_XPATH = '/metadata/idinfo/timeperd/timeinfo'
-    FGDC_SINGLE_DATE_XPATH = "#{FGDC_TIMEINFO_XPATH}/sngdate/caldate"
-    FGDC_DATE_RANGE_XPATH = "#{FGDC_TIMEINFO_XPATH}/rngdates"
+    FGDC_SINGLE_DATE_XPATH = "#{FGDC_TIMEINFO_XPATH}/sngdate/caldate".freeze
+    FGDC_DATE_RANGE_XPATH = "#{FGDC_TIMEINFO_XPATH}/rngdates".freeze
     # NOTE: saw no "#{FGDC_TIMEINFO_XPATH}/mdattim" multiple dates path data
 
     # Extracts dates from FGDC idinfo/timeperd to create a single date range value
@@ -238,7 +238,7 @@ module Macros
 
     TEI_MS_DESC_LOWER = '//tei:teiheader/tei:filedesc/tei:sourcedesc/tei:msdesc'
     TEI_MS_ORIGIN_LOWER = 'tei:history/tei:origin'
-    TEI_ORIG_DATE_PATH_LOWER = "#{TEI_MS_DESC_LOWER}/#{TEI_MS_ORIGIN_LOWER}/tei:origdate"
+    TEI_ORIG_DATE_PATH_LOWER = "#{TEI_MS_DESC_LOWER}/#{TEI_MS_ORIGIN_LOWER}/tei:origdate".freeze
     # extracts dates from TEI origDate element for Penn Openn data
     # Best dates will be in notBefore/notAfter attributes, or from/to attributes
     # 'when' attribute is usually a single date;

--- a/lib/macros/each_record.rb
+++ b/lib/macros/each_record.rb
@@ -12,7 +12,7 @@ module Macros
     # @example
     #   convert_to_language_hash => lambda { ... }
     # @return [Proc] a proc that traject can call for each record
-    def convert_to_language_hash(*fields) # rubocop:disable Metrics/PerceivedComplexity
+    def convert_to_language_hash(*fields)
       # If needed for the log messages, getting caller info here is more helpful, because it'll
       # get us the calling config (invoking caller_locations from the lambda returns a call stack
       # entirely within the traject gem, besides this method).
@@ -32,7 +32,7 @@ module Macros
           unique_values.each do |value|
             case value
             when Hash
-              sub_values = value[:values].reject(&:nil?).reject(&:empty?)
+              sub_values = value[:values].compact.reject(&:empty?)
               html_cleaned = html_check(sub_values)
               sub_values = html_cleaned
               result[value[:language]] += sub_values.uniq.tap do |unique_sub_values|

--- a/lib/macros/qnl.rb
+++ b/lib/macros/qnl.rb
@@ -71,7 +71,7 @@ module Macros
         name_and_role = names.zip(roles)
         name_with_role = []
         name_and_role.each do |val|
-          name_with_role << val[0] + ' (' + val[1] + ')'
+          name_with_role << (val[0] + ' (' + val[1] + ')')
         end
         accumulator.replace(name_with_role)
       end

--- a/spec/lib/traject/macros/cambridge_spec.rb
+++ b/spec/lib/traject/macros/cambridge_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Macros::Cambridge do
 
     context 'when all elements and attribute values present' do
       let(:extent) do
-        '<tei:extent> 368 ff.<tei:dimensions type="leaf" unit="cm"><tei:height>32.5</tei:height>'\
-        '<tei:width>23</tei:width></tei:dimensions></tei:extent>'
+        '<tei:extent> 368 ff.<tei:dimensions type="leaf" unit="cm"><tei:height>32.5</tei:height>' \
+          '<tei:width>23</tei:width></tei:dimensions></tei:extent>'
       end
 
       it 'returns values in a formatted string' do
@@ -53,14 +53,14 @@ RSpec.describe Macros::Cambridge do
 
     context 'when multiple instances and all elements and attribute values present' do
       let(:extent) do
-        '<tei:extent> 368 ff.<tei:dimensions type="leaf" unit="cm"><tei:height>32.5</tei:height>'\
-        '<tei:width>23</tei:width></tei:dimensions><tei:dimensions type="written" unit="cm">'\
-        '<tei:height>27</tei:height><tei:width>19</tei:width></tei:dimensions></tei:extent>'
+        '<tei:extent> 368 ff.<tei:dimensions type="leaf" unit="cm"><tei:height>32.5</tei:height>' \
+          '<tei:width>23</tei:width></tei:dimensions><tei:dimensions type="written" unit="cm">' \
+          '<tei:height>27</tei:height><tei:width>19</tei:width></tei:dimensions></tei:extent>'
       end
 
       it 'returns values in a formatted string' do
-        expect(indexer.map_record(ng_rec)).to eq('dimensions' => ['368 ff. Leaf: (height: 32.5 cm, width:'\
-                                                  ' 23 cm)', 'Written: (height: 27 cm, width: 19 cm)'])
+        expect(indexer.map_record(ng_rec)).to eq('dimensions' => ['368 ff. Leaf: (height: 32.5 cm, width: ' \
+                                                                  '23 cm)', 'Written: (height: 27 cm, width: 19 cm)'])
       end
     end
 

--- a/spec/lib/traject/macros/each_record_spec.rb
+++ b/spec/lib/traject/macros/each_record_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Macros::EachRecord do
 
       let(:output_hash) { { 'cho_title' => ['title1'] } }
       let(:missing_lang_err_msg) do
-        "each_record_spec.rb: key=cho_title; value=.*; 'none' not allowed as IR language key, "\
-        'language must be specified.  Check source data and/or traject config for errors'
+        "each_record_spec.rb: key=cho_title; value=.*; 'none' not allowed as IR language key, " \
+          'language must be specified.  Check source data and/or traject config for errors'
       end
 
       it 'logs an error indicating that the output is missing language' do
@@ -52,7 +52,7 @@ RSpec.describe Macros::EachRecord do
 
         it 'logs a warning indicating that duplicate values were found' do
           expect { macro.call(nil, mock_context) }.to raise_error(Macros::EachRecord::UnspecifiedLanguageError, /#{missing_lang_err_msg}/)
-          err_msg = Regexp.escape('each_record_spec.rb: key=cho_title; values=["title1", "title1"]; values array contains duplicates.  '\
+          err_msg = Regexp.escape('each_record_spec.rb: key=cho_title; values=["title1", "title1"]; values array contains duplicates.  ' \
                                   'Check source data and/or traject config for errors')
           expect(::DLME::Utils.logger).to have_received(:warn).with(a_string_matching(err_msg))
         end
@@ -80,7 +80,7 @@ RSpec.describe Macros::EachRecord do
 
         it 'logs a warning indicating that duplicate values were found' do
           macro.call(nil, mock_context)
-          err_msg = Regexp.escape('each_record_spec.rb: key=cho_title; sub_values=["title1", "title1"]; sub_values array contains duplicates.  '\
+          err_msg = Regexp.escape('each_record_spec.rb: key=cho_title; sub_values=["title1", "title1"]; sub_values array contains duplicates.  ' \
                                   'Check source data and/or traject config for errors.')
           expect(::DLME::Utils.logger).to have_received(:warn).with(a_string_matching(err_msg))
         end

--- a/spec/lib/traject/macros/iiif_spec.rb
+++ b/spec/lib/traject/macros/iiif_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Macros::IIIF do
   end
   let(:instance) { klass.new }
   let(:fixture_file_path) { File.join('./spec/fixtures/fr426cg9537.json') }
-  let(:iiif_json) { JSON.parse(File.open(fixture_file_path).read) }
+  let(:iiif_json) { JSON.parse(File.read(fixture_file_path)) }
 
   describe '#iiif_thumbnail_id' do
     subject(:iiif_thumbnail_id) { instance.iiif_thumbnail_id(iiif_json) }

--- a/spec/lib/traject/macros/string_helper_spec.rb
+++ b/spec/lib/traject/macros/string_helper_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Macros::StringHelper do
         string = "Euchologion ad usum Melchitarum,    \n     partim arabice partim syriace,
         cum titulis et rubricis plerumque    \n     mere arabicis, prinicpio       et fine mutilum."
         callable = instance.squish
-        expect(callable.call(nil, [string])).to eq(['Euchologion ad usum Melchitarum, partim arabice partim '\
-                                                    'syriace, cum titulis et rubricis plerumque mere arabicis, '\
+        expect(callable.call(nil, [string])).to eq(['Euchologion ad usum Melchitarum, partim arabice partim ' \
+                                                    'syriace, cum titulis et rubricis plerumque mere arabicis, ' \
                                                     'prinicpio et fine mutilum.'])
       end
     end
@@ -70,16 +70,16 @@ RSpec.describe Macros::StringHelper do
 
     context 'when extracted string longer than 100 charachters' do
       it 'truncates string on first white space after character 100, adds ellipsis' do
-        arabic_string = 'تتعلق المراسلات وأوراق أخرى بزيارات قامت بها شخصيات أوروبية وأمريكية إلى '\
-        'المملكة العربية السعودية، وتحديدًا إلى الرياض:زيارة في سنة ١٩٣٧قام بها '\
-        'المقدم هارولد ريتشارد باتريك ديكسون، الوكيل السياسي السابق في الكويت'
+        arabic_string = 'تتعلق المراسلات وأوراق أخرى بزيارات قامت بها شخصيات أوروبية وأمريكية إلى ' \
+                        'المملكة العربية السعودية، وتحديدًا إلى الرياض:زيارة في سنة ١٩٣٧قام بها ' \
+                        'المقدم هارولد ريتشارد باتريك ديكسون، الوكيل السياسي السابق في الكويت'
         latin_string = 'Euchologion ad usum Melchitarum, partim arabice partim syriace, cum titulis et rubricis plerumque
         mere arabicis, prinicpio et fine mutilum. Codicem meorat Cyrillus Charon (Korolevski) apud Χρυσοστομικά,
         Romae, 1908, pp. 673 sq. Cf. cod. Vat. ar. 54 ; iisdem notis utimur ac in codice laudato.'
-        expect(instance.truncate(arabic_string)).to eq('تتعلق المراسلات وأوراق أخرى بزيارات قامت بها شخصيات '\
-          'أوروبية وأمريكية إلى المملكة العربية السعودية...')
-        expect(instance.truncate(latin_string)).to eq('Euchologion ad usum Melchitarum, partim arabice partim syriace, '\
-          'cum titulis et rubricis plerumque...')
+        expect(instance.truncate(arabic_string)).to eq('تتعلق المراسلات وأوراق أخرى بزيارات قامت بها شخصيات ' \
+                                                       'أوروبية وأمريكية إلى المملكة العربية السعودية...')
+        expect(instance.truncate(latin_string)).to eq('Euchologion ad usum Melchitarum, partim arabice partim syriace, ' \
+                                                      'cum titulis et rubricis plerumque...')
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

This is just a rubocop update. This unpins the rubocop gem(s) and enable new cops, then corrects any linting issues raised by the new cops.


## How was this change tested?



## Which documentation and/or configurations were updated?



