### PR TITLE
Avoid outputting nil when parsing csv array values

### DIFF
--- a/lib/macros/csv.rb
+++ b/lib/macros/csv.rb
@@ -20,7 +20,7 @@ module Macros
     # Determine if the value in the given column contains an array of values
     # return either the original value or the array value parsed into elements
     def parse_csv
-      lambda do |_row, accumulator, context|
+      lambda do |_row, accumulator|
         return [] if accumulator.empty?
         return accumulator unless accumulator.first.match?(/[\[\]]/)
 

--- a/lib/macros/csv.rb
+++ b/lib/macros/csv.rb
@@ -20,12 +20,13 @@ module Macros
     # Determine if the value in the given column contains an array of values
     # return either the original value or the array value parsed into elements
     def parse_csv
-      lambda do |_row, accumulator|
+      lambda do |_row, accumulator, context|
         return [] if accumulator.empty?
         return accumulator unless accumulator.first.match?(/[\[\]]/)
 
-        values = accumulator.first.gsub("', '", "','")
-        accumulator.replace(CSV.parse(values.delete('[]'), liberal_parsing: true, quote_char: "'").first)
+        values = CSV.parse(accumulator.first.gsub("', '", "','").delete('[]'), liberal_parsing: true, quote_char: "'")
+        values.map!(&:compact)
+        accumulator.replace(values.first)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #939 

Since often the array from the CSV becomes nested, we need to compact the array.


## How was this change tested?



## Which documentation and/or configurations were updated?



