### PR TITLE
Princeton

### DIFF
--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -46,13 +46,13 @@ module Macros
       from_settings('agg_data_provider_country_ar')
     end
 
-    # Override the traject default method, passing two values-one English, one Arabic-instead of none
+    # Similar to the traject default method, passing two values-one English, one Arabic-instead of none
     # and adding language keys. Cannot use this method in conjunction with the lang method. Call them
     # on seperate lines.
     # @example
     #  # to_field 'cho_title', extract_tei("tei:title"), lang('en')
-    #  # to_field 'cho_title', extract_tei("tei:title"), default('Untitled', 'بدون عنوان')
-    def default(default_en, default_ar)
+    #  # to_field 'cho_title', extract_tei("tei:title"), default_multi_lang('Untitled', 'بدون عنوان')
+    def default_multi_lang(default_en, default_ar)
       lambda do |_rec, acc|
         if acc.all?(
           &:blank?

--- a/lib/translation_maps/has_type_from_collection.yaml
+++ b/lib/translation_maps/has_type_from_collection.yaml
@@ -1,4 +1,10 @@
 # Get cho_has_type values from Turkish strings
+aub-aco: Books
+aub-aladab: Serials
+aub-poha: Oral History
+aub-postcards: Postcards
+aub-posters: Posters
+aub-travelbooks: Books
 auc-bint-al-nil: Serials
 auc-coptic: Manuscripts
 auc-creswell: Photographs
@@ -10,3 +16,7 @@ auc-taxiphote-slides: Photographs
 auc-wassef: Drawings
 lau-lebanese-painters: Paintings
 lau-ottoman-embroidery: Embroidery
+princeton-babi-bahai: Manuscripts
+princeton-islamic-manuscripts: Manuscripts
+princeton-movie-posters: Posters
+princeton-ymdi: Manuscripts

--- a/lib/translation_maps/has_type_from_collection_id.yaml
+++ b/lib/translation_maps/has_type_from_collection_id.yaml
@@ -1,6 +1,0 @@
-aub-aco: Books
-aub-aladab: Serials
-aub-poha: Oral History
-aub-postcards: Postcards
-aub-posters: Posters
-aub-travelbooks: Books

--- a/lib/translation_maps/lang_from_downcased.yaml
+++ b/lib/translation_maps/lang_from_downcased.yaml
@@ -1,6 +1,7 @@
 altaic languages: Altaic Languages
 amharic: Amharic
 arabic: Arabic
+arabic;: Arabic
 aramaic: Aramaic
 aramaic, christian palestinian: Aramaic
 aratur: Aratur
@@ -27,6 +28,9 @@ hebrew (isolated tiberian vocalisation): Hebrew
 hebrew, occasional tiberian vocalisation (approx. 200 fully or partially vocalised forms): Hebrew
 indic languages: Indic Languages
 indonesian: Indonesian
+in ottoman turkish: Turkish, Ottoman (1500-1928)
+in persian: Persian
+in urdu: Urdu
 italian: Italian
 judeo arabic: Judeo-Arabic
 judaeo arabic: Judeo-Arabic
@@ -37,10 +41,13 @@ judaeo-persian: Judeo-Persian
 judaeo-portuguese: Judeo-Portuguese
 judaeo-spanish: Ladino
 latin: Latin
+malay in arabic script: Malay
 malay: Malay
 minaic: Minaic
 old bulgarian: Old Bulgarian
+ottoman (1500-1928): Turkish, Ottoman (1500-1928)
 ottoman turkish: Turkish, Ottoman (1500-1928)
+ottoman turkish,: Turkish, Ottoman (1500-1928)
 pahlavi: Pahlavi
 persian: Persian
 portuguese: Portuguese
@@ -51,6 +58,7 @@ slavic languages: Slavic Languages
 spanish: Spanish
 syriac: Syriac
 tatar: Tatar
+turkish in arabic script: Turkish, Ottoman (1500-1928)
 turkish, ottoman: Turkish, Ottoman (1500-1928)
 turkish, ottoman (1500-1928): Turkish, Ottoman (1500-1928)
 turkish: Turkish

--- a/spec/lib/traject/macros/dlme_spec.rb
+++ b/spec/lib/traject/macros/dlme_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe Macros::DLME do
   end
   let(:instance) { klass.new }
 
-  describe '#default' do
+  describe '#default_multi_lang' do
     it 'returns a Proc' do
-      expect(instance.default('Untitled', 'بدون عنوان')).to be_a(Proc)
+      expect(instance.default_multi_lang('Untitled', 'بدون عنوان')).to be_a(Proc)
     end
 
     context 'with no values in accumulator' do
       it 'replaces accumulator with default value' do
         accumulator_original = []
-        callable = instance.default('Untitled', 'بدون عنوان')
+        callable = instance.default_multi_lang('Untitled', 'بدون عنوان')
         expect(callable.call(nil, accumulator_original)).to eq(
           [{ language: 'en', values: ['Untitled'] }, { language: 'ar-Arab', values: ['بدون عنوان'] }]
         )

--- a/traject_configs/aub.rb
+++ b/traject_configs/aub.rb
@@ -63,10 +63,10 @@ to_field 'cho_date_range_hijri', column('date'), parse_csv, strip, parse_range, 
 to_field 'cho_date_range_norm', column('date'), parse_csv, strip, parse_range
 to_field 'cho_dc_rights', column('rights'), parse_csv, strip, lang('en')
 to_field 'cho_description', column('description'), strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection_id'), translation_map('edm_type_from_has_type'), lang('en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection_id'), translation_map('edm_type_from_has_type'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection_id'), lang('en')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection_id'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection'), translation_map('edm_type_from_has_type'), lang('en')
+to_field 'cho_edm_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection'), translation_map('edm_type_from_has_type'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection'), lang('en')
+to_field 'cho_has_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('aub-'), translation_map('has_type_from_collection'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_identifier', column('identifier'), parse_csv, strip
 to_field 'cho_language', column('language'), parse_csv, split(';'),
          split(','), strip, normalize_language, lang('en')

--- a/traject_configs/bodleian.rb
+++ b/traject_configs/bodleian.rb
@@ -54,7 +54,7 @@ to_field 'id', column('id'),
          strip,
          gsub('https://iiif.bodleian.ox.ac.uk/iiif/manifest/', ''),
          gsub('.json', '')
-to_field 'cho_title', column('title'), strip, arabic_script_lang_or_default('und-Arab', 'und-Latn'), default('Untitled', 'بدون عنوان')
+to_field 'cho_title', column('title'), strip, arabic_script_lang_or_default('und-Arab', 'und-Latn'), default_multi_lang('Untitled', 'بدون عنوان')
 
 # Cho Other
 to_field 'cho_alternate', column('other-titles'), arabic_script_lang_or_default('und-Arab', 'und-Latn')

--- a/traject_configs/princeton.rb
+++ b/traject_configs/princeton.rb
@@ -50,50 +50,57 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('princeton-')
 
 # Cho Required
-to_field 'id', column('identifier'), split('alt='), first_only, parse_csv, strip, gsub("<a href='http://arks.princeton.edu/", ''), gsub("'", '')
-# uniform_title is not being used but should be if authority control is applied to title field
-to_field 'cho_title', column('title'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_title', column('uniform-title'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'id', column('identifier'), split("' alt="), first_only, parse_csv, strip, unique, gsub("<a href='http://arks.princeton.edu/", '')
+to_field 'cho_title', column('title'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_title', column('uniform-title'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
 
 # Cho Other
-to_field 'cho_alternative', column('alternative'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_creator', column('author'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_creator', column('creator'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', column('contributor'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', column('director'), parse_csv, strip, prepend('Director: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_contributor', column('rendered-actors'), parse_csv, strip, prepend('Actor: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_date', column('date'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_norm', column('date'), parse_csv, strip, parse_range
-to_field 'cho_date_range_hijri', column('date'), parse_csv, strip, parse_range, hijri_range
-to_field 'cho_date', column('date-created'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_norm', column('date-created'), parse_csv, strip, parse_range
-to_field 'cho_date_range_hijri', column('date-created'), parse_csv, strip, parse_range, hijri_range
+to_field 'cho_alternative', column('alternative'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_creator', column('author'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_creator', column('creator'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('artist'), parse_csv, strip, unique, prepend('Artist: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('abridger'), parse_csv, strip, unique, prepend('Abridger: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('annotator'), parse_csv, strip, unique, prepend('Annotator: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('calligrapher'), parse_csv, strip, unique, prepend('Calligrapher: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('compiler'), parse_csv, strip, unique, prepend('Compiler: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('contributor'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('director'), parse_csv, strip, unique, prepend('Director: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_contributor', column('rendered-actors'), parse_csv, strip, unique, prepend('Actor: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('scribe'), parse_csv, strip, unique, prepend('Scribe: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', column('translator'), parse_csv, strip, unique, prepend('Translator: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_date', column('date'), parse_csv, strip, unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_norm', column('date'), parse_csv, strip, unique, parse_range
+to_field 'cho_date_range_hijri', column('date'), parse_csv, strip, unique, parse_range, hijri_range
+to_field 'cho_date', column('date-created'), parse_csv, strip, unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_norm', column('date-created'), parse_csv, strip, unique, parse_range
+to_field 'cho_date_range_hijri', column('date-created'), parse_csv, strip, unique, parse_range, hijri_range
 to_field 'cho_dc_rights', literal('https://rbsc.princeton.edu/services/imaging-publication-services'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('abstract'), parse_csv, strip, prepend('Abstract: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('binding-note'), parse_csv, strip, prepend('Binding note: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('contents'), parse_csv, strip, prepend('Contents: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('description'), parse_csv, strip, lang('en')
-to_field 'cho_edm_type', literal('Text'), lang('en')
-to_field 'cho_edm_type', literal('Text'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_extent', column('extent'), parse_csv, strip, lang('en')
-to_field 'cho_has_type', literal('Manuscripts'), lang('en')
-to_field 'cho_has_type', literal('Manuscripts'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_description', column('abstract'), parse_csv, strip, unique, prepend('Abstract: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', column('binding-note'), parse_csv, strip, unique, prepend('Binding note: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', column('contents'), parse_csv, strip, unique, prepend('Contents: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', column('description'), parse_csv, strip, unique, lang('en')
+to_field 'cho_edm_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('princeton-'), translation_map('has_type_from_collection'), translation_map('edm_type_from_has_type'), unique, lang('en')
+to_field 'cho_edm_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('princeton-'), translation_map('has_type_from_collection'), translation_map('edm_type_from_has_type'), translation_map('edm_type_ar_from_en'), unique, lang('ar-Arab')
+to_field 'cho_extent', column('extent'), parse_csv, strip, unique, lang('en')
+to_field 'cho_has_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('princeton-'), translation_map('has_type_from_collection'), unique, lang('en')
+to_field 'cho_has_type', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('princeton-'), translation_map('has_type_from_collection'), translation_map('has_type_ar_from_en'), unique, lang('ar-Arab')
 to_field 'cho_identifier', column('call-number'), parse_csv, strip
 to_field 'cho_identifier', column('identifier'), parse_csv, strip
 to_field 'cho_identifier', column('local-identifier'), parse_csv, strip
-to_field 'cho_identifier', column('replaces'), parse_csv, strip, prepend('Replaces: ')
-to_field 'cho_is_part_of', column('member-of-collections'), parse_csv, strip, lang('en')
-to_field 'cho_language', column('language'), parse_csv, gsub('.', ''), strip, normalize_language, lang('en')
-to_field 'cho_language', column('language'), parse_csv, gsub('.', ''), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_language', column('text-language'), parse_csv, gsub('.', ''), strip, normalize_language, lang('en')
-to_field 'cho_language', column('text-language'), parse_csv, gsub('.', ''), strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_provenance', column('provenance'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_publisher', column('publisher'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_spatial', column('geographic-origin'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_subject', column('genre'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_subject', column('subject'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_type', column('resource-type'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_type', column('type'), parse_csv, strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_identifier', column('replaces'), parse_csv, strip, unique, prepend('Replaces: ')
+to_field 'cho_is_part_of', column('member-of-collections'), parse_csv, strip, unique, lang('en')
+# Leaving out the 'text-language' column because its mostly redundant.
+to_field 'cho_language', column('language'), parse_csv, strip, normalize_language, unique, lang('en')
+to_field 'cho_language', column('language'), parse_csv, strip, normalize_language, translation_map('lang_ar_from_en'), unique, lang('ar-Arab')
+to_field 'cho_provenance', column('collector'), prepend('Collector: '), parse_csv, strip, unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', column('former-owner'), prepend('Former owner: '), parse_csv, strip, unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', column('provenance'), parse_csv, strip, unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_publisher', column('publisher'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_spatial', column('geographic-origin'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_subject', column('genre'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_subject', column('subject'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_type', column('resource-type'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_type', column('type'), parse_csv, strip, unique, arabic_script_lang_or_default('und-Arab', 'en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -106,9 +113,11 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
                                   'wr_id' => [column('identifier'), split("Identifier'>"), last, split('</a>'), first_only, parse_csv, strip],
                                   'wr_is_referenced_by' => column('id'))
 end
+# One record is missing 'thumbnail' value. To get around that, we pass a generic thumnail image to `default`.
+# This should be removed once Princeton fixes the data issue.
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
-                                  'wr_id' => [column('thumbnail'), parse_csv, first_only, split('/full/'), strip, append('/full/!400,400/0/default.jpg')],
+                                  'wr_id' => [column('thumbnail'), parse_csv, first_only, split('/full/'), strip, append('/full/!400,400/0/default.jpg'), default('https://iiif-cloud.princeton.edu/iiif/2/ce%2Fa3%2F3e%2Fcea33ed8c16141de94a3414f38290306%2Fintermediate_file/full/!400,400/0/default.jpg')],
                                   'wr_is_referenced_by' => column('id'))
 end
 to_field 'agg_provider', provider, lang('en')


### PR DESCRIPTION
## Why was this change made?

Fixes issues in Princeton traject, after changes to harvest via airflow. Traject has a `default` macro which was overridden by our own macro of the same name; our macro functioned the same but took two strings (one Arabic and one English) and assigned one of them depending on the language of the metadata. Turns out we still need the standard `default` macro so the PR renames our own so we have access to both.

## How was this change tested?

Local transform and load in dev

## Which documentation and/or configurations were updated?

n/a

