### PR TITLE
Handle Python list in CSV edge cases

### DIFF
--- a/lib/macros/csv.rb
+++ b/lib/macros/csv.rb
@@ -25,6 +25,21 @@ module Macros
         return [] if accumulator.empty?
         return accumulator unless accumulator.first.match?(/[\[\]]/)
 
+        values = CSV.parse(accumulator.first.gsub("', '", "','").delete('[]'), liberal_parsing: true, quote_char: "'")
+        values.map!(&:compact)
+        accumulator.replace(values.first)
+      end
+    end
+
+    # Same as parse_csv but parses YAML instead of CSV.
+    # We ran into an issue when parsing titles that were serialized like: ["'example,']
+    # Assuming this works the goal is to move towards always parsing as YAML
+    # with a parse_list function and to retire parse_csv
+    def parse_yaml
+      lambda do |_row, accumulator|
+        return [] if accumulator.empty?
+        return accumulator unless accumulator.first.match?(/[\[\]]/)
+
         values = YAML.safe_load(accumulator.first)
         accumulator.replace(values)
       end

--- a/lib/macros/csv.rb
+++ b/lib/macros/csv.rb
@@ -3,6 +3,7 @@
 require 'active_support/inflector' # parameterize method is part of active support
 require 'byebug'
 require 'csv'
+require 'yaml'
 
 module Macros
   # Macros for extracting values from CSV rows
@@ -24,9 +25,8 @@ module Macros
         return [] if accumulator.empty?
         return accumulator unless accumulator.first.match?(/[\[\]]/)
 
-        values = CSV.parse(accumulator.first.gsub("', '", "','").delete('[]'), liberal_parsing: true, quote_char: "'")
-        values.map!(&:compact)
-        accumulator.replace(values.first)
+        values = YAML.safe_load(accumulator.first)
+        accumulator.replace(values)
       end
     end
   end

--- a/spec/lib/traject/macros/csv_spec.rb
+++ b/spec/lib/traject/macros/csv_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Macros::Csv do
 
     context 'with weird comma problem' do
       it 'parses ok' do
-        text = %q("'test,'")
-        result = CSV.parse(text, liberal_parsing: true, quote_char: "'")
-        expect(result.length).to eq(1)
+        text = [%q(['"مرفقات برسائل سرية من بومباي،" المجلد ٣٦', "'ENCLOSURES TO SECRET LETTERS FROM BOMBAY,' Vol 36"])]
+        result = instance.parse_csv.call(nil, text)
+        expect(result.length).to eq(2)
       end
     end
   end

--- a/spec/lib/traject/macros/csv_spec.rb
+++ b/spec/lib/traject/macros/csv_spec.rb
@@ -39,5 +39,14 @@ RSpec.describe Macros::Csv do
         expect(callable.call(nil, accumulator_original)).to eq(['this', 'is', 'my', 'dummy', 'string'])
       end
     end
+
+    context 'with an array value with double quotes in accumulator' do
+      it 'parses ok' do
+        accumulator_original = [%Q("['""ﻡﺮﻔﻗﺎﺗ ﺏﺮﺳﺎﺌﻟ ﺱﺮﻳﺓ ﻢﻧ ﺏﻮﻤﺑﺎﻳ،"" ﺎﻠﻤﺠﻟﺩ ٣٦', ""'ENCLOSURES TO SECRET LETTERS FROM BOMBAY,' Vol 36""]")]
+        callable = instance.parse_csv
+        result = callable.call(nil, accumulator_original)
+        expect(result.length).to eq(2)
+     end
+    end
   end
 end

--- a/spec/lib/traject/macros/csv_spec.rb
+++ b/spec/lib/traject/macros/csv_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'csv'
 require 'macros/csv'
 
 RSpec.describe Macros::Csv do
@@ -40,13 +41,12 @@ RSpec.describe Macros::Csv do
       end
     end
 
-    context 'with an array value with double quotes in accumulator' do
+    context 'with weird comma problem' do
       it 'parses ok' do
-        accumulator_original = [%Q("['""ﻡﺮﻔﻗﺎﺗ ﺏﺮﺳﺎﺌﻟ ﺱﺮﻳﺓ ﻢﻧ ﺏﻮﻤﺑﺎﻳ،"" ﺎﻠﻤﺠﻟﺩ ٣٦', ""'ENCLOSURES TO SECRET LETTERS FROM BOMBAY,' Vol 36""]")]
-        callable = instance.parse_csv
-        result = callable.call(nil, accumulator_original)
-        expect(result.length).to eq(2)
-     end
+        text = %q("'test,'")
+        result = CSV.parse(text, liberal_parsing: true, quote_char: "'")
+        expect(result.length).to eq(1)
+      end
     end
   end
 end

--- a/spec/lib/traject/macros/csv_spec.rb
+++ b/spec/lib/traject/macros/csv_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Macros::Csv do
       end
     end
 
-    context 'with weird comma problem' do
-      it 'parses ok' do
+    context 'with single quote comma problem' do
+      it 'parses ok as YAML' do
         text = [%q(['"مرفقات برسائل سرية من بومباي،" المجلد ٣٦', "'ENCLOSURES TO SECRET LETTERS FROM BOMBAY,' Vol 36"])]
-        result = instance.parse_csv.call(nil, text)
+        result = instance.parse_yaml.call(nil, text)
         expect(result.length).to eq(2)
       end
     end

--- a/traject_configs/qnl.rb
+++ b/traject_configs/qnl.rb
@@ -54,7 +54,7 @@ to_field 'agg_data_provider_collection_id', literal('qnl')
 # CHO Required
 to_field 'id', column('id'), parse_csv, at_index(0), gsub('_ar', '_dlme'), gsub('_en', '_dlme')
 # 'titleInfo_title' has mixed language content, don't use arabic_script_lang_or_default macro
-to_field 'cho_title', column('title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', column('title'), parse_yaml, strip, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # CHO Other
 to_field 'cho_creator', column('author'), parse_csv, strip, gsub('NOT PROVIDED', ''), prepend('Author: '), arabic_script_lang_or_default('ar-Arab', 'en')


### PR DESCRIPTION
## Why was this change made?

Added a `parse_yaml` function to handle some edge case titles from QNL which contain single-quotes enclosing some text a comma which in turn throws a CSV parser error.

I think we can parse all the lists as YAML, without needing to strip square brackets, and extraneous white space. But @aaron-collier thought it might be safer to add a new function for use exclusively with QNL titles, and then use it more broadly if it proves to work ok.

## How was this change tested?

Added a new test for the edge case.

## Which documentation and/or configurations were updated?



