### PR TITLE
Only update the accumulator if there is a value at the provided index

### DIFF
--- a/lib/macros/dlme.rb
+++ b/lib/macros/dlme.rb
@@ -125,7 +125,7 @@ module Macros
 
     def at_index(index)
       lambda do |_rec, acc|
-        acc.replace([acc[index]])
+        acc.replace([acc[index]]) if acc[index]
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

`at_index` currently introduces a bug where if there is no value at `acc[index]` the accumulator is replaces with an array of a single nil element (i.e. `[nil]`) this is causing a breaking error in traject.

## How was this change tested?

Manual transform of QNL (20k records)

## Which documentation and/or configurations were updated?



