### PR TITLE
Fix small bug that caused record duplication on subsequent runs in d…

### DIFF
--- a/invoke.sh
+++ b/invoke.sh
@@ -5,13 +5,9 @@ DATA_PATH=${DATA_PATH:-$1} # Get the data dir from the environment first if it e
 DATA_DIR=$DATA_PATH
 DATA_DIR=${DATA_DIR//\//-}
 DEBUG_FLAG=$2
-DOWNLOAD_PATH=${DATA_PATH%/*}
-SOURCE_DATA="/opt/airflow/working/$DATA_PATH"
+SOURCE_DATA="/opt/airflow/working"
 METADATA_PATH="/opt/airflow/metadata/$DATA_PATH"
 mkdir -p ${METADATA_PATH}
-
-mkdir -p /opt/traject/data
-cp -R $SOURCE_DATA /opt/traject/data/$DOWNLOAD_PATH
 
 echo "Starting dlme-transform for: ${DATA_PATH}"
 
@@ -19,6 +15,6 @@ OUTPUT_FILENAME="output-$DATA_DIR.ndjson"
 SUMMARY_FILEPATH="output/summary-$DATA_DIR.json"
 
 set +e
-exe/transform --summary-filepath $SUMMARY_FILEPATH --data-dir $DATA_PATH $DEBUG_FLAG | tee "$METADATA_PATH/$OUTPUT_FILENAME"
+exe/transform --summary-filepath $SUMMARY_FILEPATH --base-data-dir $SOURCE_DATA --data-dir $DATA_PATH $DEBUG_FLAG | tee "$METADATA_PATH/$OUTPUT_FILENAME"
 
 echo "Dlme-transform complete for: ${DATA_PATH}"


### PR DESCRIPTION
…ocker

This fixes a small bug that shows up if you run the same provider through transform multiple times. Without clearing up the `traject/data/...` path we end up with duplicate records in the output ndjson. This mounts the provided input path to `/opt/airflow/working` and reads directly from there instead of copying data around.

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



