### PR TITLE
Switch QNL to JSON parsing

### DIFF
--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -926,7 +926,7 @@
     "paths": [
       "qnl/british_library_combined"
     ],
-    "extension": ".csv",
+    "extension": ".json",
     "settings": {
       "agg_provider": "Qatar National Library",
       "agg_provider_country": "Qatar",

--- a/traject_configs/qnl.rb
+++ b/traject_configs/qnl.rb
@@ -3,7 +3,6 @@
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
 require 'macros/collection'
-require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
@@ -11,6 +10,7 @@ require 'macros/iiif'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
+require 'macros/path_to_file'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -19,7 +19,6 @@ require 'macros/version'
 require 'traject_plus'
 
 extend Macros::Collection
-extend Macros::Csv
 extend Macros::DLME
 extend Macros::DateParsing
 extend Macros::EachRecord
@@ -27,17 +26,18 @@ extend Macros::IIIF
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
+extend Macros::PathToFile
 extend Macros::QNL
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
 extend Macros::Version
 extend TrajectPlus::Macros
-extend TrajectPlus::Macros::Csv
+extend TrajectPlus::Macros::JSON
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
-  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+  provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
 
 # Set Version & Timestamp on each record
@@ -52,36 +52,35 @@ to_field 'agg_data_provider_collection', literal('qnl'), translation_map('agg_co
 to_field 'agg_data_provider_collection_id', literal('qnl')
 
 # CHO Required
-to_field 'id', column('id'), parse_csv, at_index(0), gsub('_ar', '_dlme'), gsub('_en', '_dlme')
+to_field 'id', extract_json('.id[0]'), gsub('_ar', '_dlme'), gsub('_en', '_dlme')
 # 'titleInfo_title' has mixed language content, don't use arabic_script_lang_or_default macro
-to_field 'cho_title', column('title'), parse_yaml, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('.title[0]'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # CHO Other
-to_field 'cho_creator', column('author'), parse_csv, strip, gsub('NOT PROVIDED', ''), prepend('Author: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date', column('originInfo_dateIssued'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_norm', column('originInfo_dateIssued'), parse_csv, strip, gsub('_', '-'), parse_range
-to_field 'cho_date_range_hijri', column('originInfo_dateIssued'),
-         parse_csv, strip, gsub('_', '-'), parse_range, hijri_range
-to_field 'cho_dc_rights', column('accessCondition'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('.author[0]'), prepend('Author: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date', extract_json('.originInfo_dateIssued[0]'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_norm', extract_json('.originInfo_dateIssued[0]'), strip, gsub('_', '-'), parse_range
+to_field 'cho_date_range_hijri', extract_json('.originInfo_dateIssued[0]'), strip, gsub('_', '-'), parse_range, hijri_range
+to_field 'cho_dc_rights', extract_json('.accessCondition[0]'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
 # 'abstract' has mixed language content, don't use arabic_script_lang_or_default macro
-to_field 'cho_description', column('abstract'), parse_csv, at_index(0), strip, prepend('ملخص: '), lang('ar-Arab')
-to_field 'cho_description', column('abstract'), parse_csv, at_index(1), strip, prepend('Abstract: '), lang('en')
+to_field 'cho_description', extract_json('.abstract[0]'), prepend('Abstract: '), lang('en')
+to_field 'cho_description', extract_json('.abstract[1]'), prepend('ملخص: '), lang('ar-Arab')
 # 'physicalDescription_extent' has mixed language content, don't use arabic_script_lang_or_default macro
-to_field 'cho_description', column('physicalDescription_extent'), parse_csv, at_index(0), strip, prepend('الوصف المادي: '), lang('ar-Arab')
-to_field 'cho_description', column('physicalDescription_extent'), parse_csv, at_index(1), strip, prepend('Physical description: '), lang('en')
-to_field 'cho_edm_type', column('genre'), parse_csv, at_index(1), normalize_has_type, normalize_edm_type, lang('en')
-to_field 'cho_edm_type', column('genre'), parse_csv, at_index(1), normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', column('genre'), parse_csv, at_index(1), normalize_has_type, lang('en')
-to_field 'cho_has_type', column('genre'), parse_csv, at_index(1), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_identifier', column('identifier'), parse_csv, strip
-to_field 'cho_identifier', column('location_shelfLocator'), parse_csv, at_index(0), strip
-to_field 'cho_is_part_of', column('location_physicalLocation'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_language', column('language_languageTerm'), parse_csv, at_index(0), normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_language', column('language_languageTerm'), parse_csv, at_index(0), normalize_language, lang('en')
-to_field 'cho_spatial', column('subject_geographic'), parse_csv, strip, gsub('NOT PROVIDED', ''), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('subject_topic'), parse_csv, strip, gsub('NOT PROVIDED', ''), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('subject_name_namePart'), parse_csv, strip, gsub('NOT PROVIDED', ''), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_type', column('genre'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('.physicalDescription_extent[0]'), prepend('Physical description: '), lang('en')
+to_field 'cho_description', extract_json('.physicalDescription_extent[1]'), prepend('الوصف المادي: '), lang('ar-Arab')
+to_field 'cho_edm_type', extract_json('.genre'), at_index(0), normalize_has_type, normalize_edm_type, lang('en')
+to_field 'cho_edm_type', extract_json('.genre'), at_index(0), normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('.genre'), at_index(0), normalize_has_type, lang('en')
+to_field 'cho_has_type', extract_json('.genre'), at_index(0), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', extract_json('.identifier'), at_index(0), strip
+to_field 'cho_identifier', extract_json('.location_shelfLocator'), at_index(0), strip
+to_field 'cho_is_part_of', extract_json('.location_physicalLocation'), at_index(0), strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_language', extract_json('.language_languageTerm'), at_index(0), normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_language', extract_json('.language_languageTerm'), at_index(0), normalize_language, lang('en')
+to_field 'cho_spatial', extract_json('.subject_geographic'), at_index(0), strip, gsub('NOT PROVIDED', ''), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('.subject_topic'), at_index(0), strip, gsub('NOT PROVIDED', ''), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('.subject_name_namePart'), at_index(0), strip, gsub('NOT PROVIDED', ''), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('.genre'), at_index(0), strip, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -92,29 +91,29 @@ to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_dc_rights' => [column('accessCondition'), parse_csv, strip],
-    'wr_edm_rights' => [column('accessCondition'), parse_csv, strip, translation_map('edm_rights_from_contributor')],
+    'wr_dc_rights' => [extract_json('.accessCondition'), at_index(0), strip],
+    'wr_edm_rights' => [extract_json('.accessCondition'), at_index(0), strip, translation_map('edm_rights_from_contributor')],
     'wr_format' => [literal('image/jpeg')],
-    'wr_id' => [column('id'), parse_csv, at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/archive/')],
-    'wr_is_referenced_by' => [column('id'), parse_csv, at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/iiif/'), append('/manifest')]
+    'wr_id' => [extract_json('.id'), at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/archive/')],
+    'wr_is_referenced_by' => [extract_json('.id'), at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/iiif/'), append('/manifest')]
   )
 end
 to_field 'agg_is_shown_by' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_edm_rights' => [column('accessCondition'), parse_csv, strip, translation_map('edm_rights_from_contributor')],
+    'wr_edm_rights' => [extract_json('.accessCondition'), at_index(0), strip, translation_map('edm_rights_from_contributor')],
     'wr_format' => literal('image/jpeg'),
-    'wr_id' => [column('shown_at'), parse_csv, strip, at_index(0)],
-    'wr_is_referenced_by' => [column('id'), parse_csv, at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/iiif/'), append('/manifest')]
+    'wr_id' => [extract_json('.shown_at'), at_index(0), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/iiif/'), append('/manifest')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
-    'wr_edm_rights' => [column('accessCondition'), parse_csv, strip, translation_map('edm_rights_from_contributor')],
+    'wr_edm_rights' => [extract_json('.accessCondition'), at_index(0), strip, translation_map('edm_rights_from_contributor')],
     'wr_format' => [literal('image/jpeg')],
-    'wr_id' => [column('preview'), parse_csv, strip, at_index(0)],
-    'wr_is_referenced_by' => [column('id'), parse_csv, at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/iiif/'), append('/manifest')]
+    'wr_id' => [extract_json('.preview'), at_index(0), strip],
+    'wr_is_referenced_by' => [extract_json('.id'), at_index(0), gsub('_ar', ''), gsub('_en', ''), prepend('https://www.qdl.qa/en/iiif/'), append('/manifest')]
   )
 end
 to_field 'agg_provider', provider, lang('en')


### PR DESCRIPTION
Switch QNL to JSON parsing

## Why was this change made?

This switches QNL transform parsing from CSV to JSON in order to address character encoding issues discovered in the CSV.

## How was this change tested?



## Which documentation and/or configurations were updated?



