### PR TITLE
This ensures the full translation of data path to filename

### DIFF
--- a/invoke.sh
+++ b/invoke.sh
@@ -4,6 +4,7 @@ set -e
 DATA_PATH=${DATA_PATH:-$1} # Get the data dir from the environment first if it exists.
 DATA_DIR=$DATA_PATH
 DATA_DIR=${DATA_DIR//\//-}
+DATA_DIR=${DATA_DIR//_/-}
 DEBUG_FLAG=$2
 SOURCE_DATA="/opt/airflow/working"
 METADATA_PATH="/opt/airflow/metadata"


### PR DESCRIPTION
## Why was this change made?

This takes a data path as `sakip_sabanci_museum/abidin_dino` and ensures the output file is `output-sakip-sabanci-museum-abidin-dino.ndjson`

## How was this change tested?



## Which documentation and/or configurations were updated?



