### PR TITLE
fix error in pppa id url

### DIFF
--- a/traject_configs/palestine_posters_project_archive.rb
+++ b/traject_configs/palestine_posters_project_archive.rb
@@ -35,7 +35,7 @@ to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
 # CHO Required
-to_field 'id', column('Resource_URL')
+to_field 'id', column('Resource_URL'), split('/poster/'), at_index(1), prepend('pppa-')
 to_field 'cho_title', column('Title'), strip, lang('en')
 
 # CHO Other


### PR DESCRIPTION
## Why was this change made?

There was an error in the resource urls caused by passing a full url in the id field; this fixes that issue.


## How was this change tested?

local transform


## Which documentation and/or configurations were updated?

n/a

