### PR TITLE
fix id in iiif_v3 collections

### DIFF
--- a/traject_configs/ucla_iiif_v3.rb
+++ b/traject_configs/ucla_iiif_v3.rb
@@ -52,7 +52,7 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(3), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-')
 
 # CHO Required
-to_field 'id', extract_json('.id'), gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), gsub('\/!200,200\/0\/default.jpg', '')
+to_field 'id', extract_json('.id'), gsub('https://iiif.library.ucla.edu/iiif/2/', ''), gsub('/full/!200,200/0/default.jpg', '')
 to_field 'cho_title', extract_json('.title[0]'), strip, arabic_script_lang_or_default('und-Arab', 'en')
 
 # CHO Other


### PR DESCRIPTION
## Why was this change made?

The id value in the iiif_v3 was a full url which prevents the records from resolving.

## How was this change tested?

Local transform

## Which documentation and/or configurations were updated?

n/a

