### PR TITLE
add DRY validation for url in id field

### DIFF
--- a/lib/contracts/cho.rb
+++ b/lib/contracts/cho.rb
@@ -3,7 +3,7 @@
 module Contracts
   # rubocop:disable Metrics/BlockLength
   # See https://github.com/sul-dlss/dlme/blob/master/docs/application_profile.md#edmprovidedcho
-  class CHO < Dry::Validation::Contract
+  class CHO < Dry::Validation::Contract # rubocop:disable Metrics/ClassLength
     json do
       optional(:cho_alternative).value(:hash?)
       optional(:cho_contributor).value(:hash?)
@@ -66,6 +66,14 @@ module Contracts
     #
     # Note that these class method *must* be defined *above* the `rule()` calls
     # below
+    def self.id_validation_rule
+      proc do
+        unexpected_values = value.include? 'http'
+        key.failure("the id field contains a url: #{key.path.keys.first}") if
+          unexpected_values
+      end
+    end
+
     def self.web_resource_validation_rule
       proc do
         error_message = key? ? validate_web_resource(value) : ''
@@ -102,6 +110,7 @@ module Contracts
     end
     # rubocop:enable Metrics/AbcSize
 
+    rule(:id, &id_validation_rule)
     rule(:cho_description, &optional_language_specific_rule)
     rule(:cho_title, &required_language_specific_rule)
     rule(:cho_language, &optional_language_specific_rule)

--- a/traject_configs/bnf.rb
+++ b/traject_configs/bnf.rb
@@ -49,7 +49,7 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('bnf-')
 
 # Cho Required
-to_field 'id', column('id'), strip
+to_field 'id', column('id'), strip, gsub('https://gallica.bnf.fr/', '')
 to_field 'cho_title', column('title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'und-Latn')
 
 # Required per data agreement

--- a/traject_configs/cambridge_genizah.rb
+++ b/traject_configs/cambridge_genizah.rb
@@ -52,7 +52,7 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('bnf-')
 
 # Cho Required
-to_field 'id', column('id'), strip
+to_field 'id', column('id'), gsub('https://cudl.lib.cam.ac.uk/iiif/', ''), strip
 to_field 'cho_title', column('title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Cho Other

--- a/traject_configs/cambridge_hebrew.rb
+++ b/traject_configs/cambridge_hebrew.rb
@@ -52,7 +52,7 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('bnf-')
 
 # Cho Required
-to_field 'id', column('id'), strip
+to_field 'id', column('id'), gsub('https://cudl.lib.cam.ac.uk/iiif/', ''), strip
 to_field 'cho_title', column('title'), parse_csv, strip, hebrew_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', column('uniform-title'), parse_csv, strip, hebrew_script_lang_or_default('ar-Arab', 'en')
 

--- a/traject_configs/cambridge_islamic.rb
+++ b/traject_configs/cambridge_islamic.rb
@@ -52,7 +52,7 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2), gsub('_', '-'), prepend('bnf-')
 
 # Cho Required
-to_field 'id', column('id'), strip
+to_field 'id', column('id'), gsub('https://cudl.lib.cam.ac.uk/iiif/', ''), strip
 to_field 'cho_title', column('title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', column('uniform-title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', column('descriptive-titles'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')

--- a/traject_configs/loc.rb
+++ b/traject_configs/loc.rb
@@ -53,7 +53,7 @@ to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(3), 
 to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('loc')
 
 # CHO Required
-to_field 'id', extract_json('.id'), strip, gsub('http://www.loc.gov/item/', ''), gsub('/', ''), prepend('loc-')
+to_field 'id', extract_json('.id'), strip, gsub('http://www.loc.gov/item/', ''), gsub('http:', ''), gsub('www.loc.gov', ''), gsub('/', ''), prepend('loc-')
 to_field 'cho_title', extract_json('.title'), strip, arabic_script_lang_or_default('und-Arab', 'en')
 
 # CHO Other

--- a/traject_configs/sakip_sabanci_museum.rb
+++ b/traject_configs/sakip_sabanci_museum.rb
@@ -52,7 +52,7 @@ to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2
 to_field 'dlme_source_file', path_to_file
 
 # Cho Required
-to_field 'id', column('id'), gsub('https://cdm21044.contentdm.oclc.org/iiif/2/', ''), gsub('/manifest.json', ''), gsub(':', '-'), transform(&:downcase)
+to_field 'id', column('id'), gsub('https://cdm21044.contentdm.oclc.org/iiif/', ''), gsub('/manifest.json', ''), gsub(':', '-'), transform(&:downcase)
 to_field 'cho_title', column('başlık-title'), parse_csv, lang('tr-Latn')
 
 # Cho Other


### PR DESCRIPTION
## Why was this change made?

We have a number of records that fail to resolve because the record id is a url. These records resolved in the past but stopped working some time ago.

## How was this change tested?

local transform

## Which documentation and/or configurations were updated?

n/a

