### PR TITLE
Switch from byebug to debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,5 @@ main.zip
 # Rspec files:
 spec/examples.txt
 
-.byebug_history
-.pry_history
 coverage
 **/.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,7 @@ gem 'thor', '~> 0.20' # for CLI
 gem 'traject_plus', '~> 1.3'
 
 group :development, :test do
-  gem 'byebug'
-  gem 'pry-byebug'
+  gem 'debug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,11 +11,12 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     deep_merge (1.2.2)
     deprecation (1.1.0)
       activesupport
@@ -100,6 +101,10 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    io-console (0.7.2)
+    irb (1.13.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.7.2)
     jsonpath (1.1.5)
       multi_json
@@ -113,7 +118,6 @@ GEM
       unf
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
-    method_source (1.1.0)
     mini_portile2 (2.8.7)
     minitest (5.23.1)
     multi_json (1.15.0)
@@ -129,17 +133,17 @@ GEM
     parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+    psych (5.1.2)
+      stringio
     public_suffix (5.0.5)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
     regexp_parser (2.9.2)
+    reline (0.5.8)
+      io-console (~> 0.5)
     rexml (3.2.9)
       strscan
     rspec (3.13.0)
@@ -194,6 +198,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
+    stringio (3.1.0)
     strscan (3.1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -228,13 +233,12 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.2)
-  byebug
   config
+  debug
   dry-validation
   faraday
   faraday_middleware
   parse_date
-  pry-byebug
   rake
   rspec
   rspec_junit_formatter

--- a/lib/macros/csic.rb
+++ b/lib/macros/csic.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'byebug'
-
 # Macros for Traject transformations.
 module Macros
   # Macro to extract only the 856u field that includes the simurg url for CSIC.

--- a/lib/macros/csv.rb
+++ b/lib/macros/csv.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_support/inflector' # parameterize method is part of active support
-require 'byebug'
 require 'csv'
 require 'yaml'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,7 @@ SimpleCov.start do
 end
 
 require 'cli'
-require 'byebug'
-require 'pry-byebug'
+require 'debug'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## Why was this change made?

Replaces byebug with the now standard debug, where `byebug` was used as a breakpoint before, `debugger` is now used.

## How was this change tested?



## Which documentation and/or configurations were updated?



