### PR TITLE
Add appropriate platform to gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,10 @@ GEM
     concurrent-ruby (1.3.3)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    csv (3.3.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -88,6 +92,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    hashdiff (1.1.0)
     hashie (5.0.0)
     http (5.2.0)
       addressable (~> 2.8)
@@ -98,6 +103,10 @@ GEM
     http-cookie (1.0.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -118,9 +127,12 @@ GEM
       unf
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.23.1)
     multi_json (1.15.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.4.1)
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
@@ -224,6 +236,10 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     yell (2.2.2)
     zeitwerk (2.6.15)
 
@@ -238,6 +254,7 @@ DEPENDENCIES
   dry-validation
   faraday
   faraday_middleware
+  httparty
   parse_date
   rake
   rspec
@@ -248,6 +265,7 @@ DEPENDENCIES
   simplecov (~> 0.21)
   thor (~> 0.20)
   traject_plus (~> 1.3)
+  webmock
 
 BUNDLED WITH
    2.4.13


### PR DESCRIPTION
## Why was this change made?

Add the required platform to the Gemfile.lock in order to run in docker.

## How was this change tested?



## Which documentation and/or configurations were updated?



