### PR TITLE
Pin ffi to a supported version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'config'
 gem 'dry-validation'
 gem 'faraday'
 gem 'faraday_middleware'
+gem 'ffi', '~> 1.16.3' # pin until 1.17.x is less platform dependent
 gem 'httparty'
 gem 'parse_date'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,10 @@ GEM
     concurrent-ruby (1.3.3)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    csv (3.3.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -83,11 +87,11 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.17.0)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.16.3)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    hashdiff (1.1.0)
     hashie (5.0.0)
     http (5.2.0)
       addressable (~> 2.8)
@@ -98,6 +102,10 @@ GEM
     http-cookie (1.0.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -118,12 +126,17 @@ GEM
       unf
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.23.1)
     multi_json (1.15.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.4.1)
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
@@ -224,10 +237,15 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     yell (2.2.2)
     zeitwerk (2.6.15)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
   x86_64-linux
 
@@ -238,6 +256,8 @@ DEPENDENCIES
   dry-validation
   faraday
   faraday_middleware
+  ffi (~> 1.16.3)
+  httparty
   parse_date
   rake
   rspec
@@ -248,6 +268,7 @@ DEPENDENCIES
   simplecov (~> 0.21)
   thor (~> 0.20)
   traject_plus (~> 1.3)
+  webmock
 
 BUNDLED WITH
    2.4.13


### PR DESCRIPTION
## Why was this change made?

Pin ffi to avoid platform mismatch.

## How was this change tested?



## Which documentation and/or configurations were updated?



