### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport', '~> 5.2'
 gem 'config'
+gem 'csv'
 gem 'dry-validation'
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    csv (3.2.8)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -242,6 +243,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2)
   config
+  csv
   debug
   dry-validation
   faraday


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.

# How was this change tested?

CI
