### PR TITLE
Quiet logging to avoid issues in airflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ docker run --rm -e SKIP_FETCH_DATA=true \
                 -v $(pwd)/.:/opt/traject \
                 -v $(pwd)/../dlme-metadata:/opt/airflow/working \
                 -v $(pwd)/output:/opt/traject/output \
+                -v $(pwd)/output:/opt/airflow/metadata \
                 suldlss/dlme-transform:latest \
                 stanford/maps/data/kj751hs0595.mods
 ```
@@ -103,6 +104,7 @@ docker run --rm -e SKIP_FETCH_DATA=true \
                 -v $(pwd)/.:/opt/traject \
                 -v $(pwd)/../dlme-metadata:/opt/airflow/working \
                 -v $(pwd)/output:/opt/traject/output \
+                -v $(pwd)/output:/opt/airflow/metadata \
                 suldlss/dlme-transform:latest \
                 stanford/maps/data/kj751hs0595.mods \
                 -w

--- a/invoke.sh
+++ b/invoke.sh
@@ -16,6 +16,6 @@ OUTPUT_FILENAME="output-$DATA_DIR.ndjson"
 SUMMARY_FILEPATH="output/summary-$DATA_DIR.json"
 
 set +e
-exe/transform --summary-filepath $SUMMARY_FILEPATH --base-data-dir $SOURCE_DATA --data-dir $DATA_PATH $DEBUG_FLAG | tee "$METADATA_PATH/$OUTPUT_FILENAME"
+exe/transform --summary-filepath $SUMMARY_FILEPATH --base-data-dir $SOURCE_DATA --data-dir $DATA_PATH $DEBUG_FLAG | tee "$METADATA_PATH/$OUTPUT_FILENAME" > /dev/null
 
 echo "Dlme-transform complete for: ${DATA_PATH}"


### PR DESCRIPTION
## Why was this change made?

Otherwise all of STDOUT goes into the airflow logs.

## How was this change tested?



## Which documentation and/or configurations were updated?



