### PR TITLE
Move AUC to json, add validation, adjust macros

### DIFF
--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -127,7 +127,7 @@
     "paths": [
       "auc"
     ],
-    "extension": ".csv",
+    "extension": ".json",
     "settings": {
       "agg_provider": "American University in Cairo",
       "agg_provider_country": "Egypt",

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,6 +35,59 @@ acceptable_bcp47_codes:
   - und-Latn
   - ur-Arab
   - ur-Latn
+acceptable_edm_type_values:
+  - Dataset
+  - Image
+  - Object
+  - Sound
+  - Text
+  - Video
+acceptable_has_type_values:
+  - Adornments
+  - Archaeological Sites
+  - Armaments
+  - Amulets
+  - Books
+  - Carpets
+  - Coins
+  - Calligraphy
+  - Containers
+  - Drawings
+  - Embroidery
+  - Funerary Objects
+  - Furniture
+  - Historical Videos
+  - Inscriptions
+  - Interviews
+  - Letters
+  - Manuscript Illuminations
+  - Manuscripts
+  - Maps
+  - Musical Instruments
+  - Notebooks
+  - Oral History
+  - Other Texts
+  - Other Videos
+  - Other Images
+  - Other Objects
+  - Oral History
+  - Paintings
+  - Photographs
+  - Posters
+  - Postcards
+  - Radio Program
+  - Recreational Artifacts
+  - Sculptures
+  - Scrolls
+  - Stelae
+  - Structures
+  - Seals
+  - Serials
+  - Tablets
+  - Text Reuse Data
+  - Tools & Equipment
+  - Weights & Measures
+  - Writing Accessories  
 defaults:
   base_data_dir: 'data'
   data_dir: ''

--- a/lib/macros/date_parsing.rb
+++ b/lib/macros/date_parsing.rb
@@ -56,7 +56,7 @@ module Macros
     # with an additional year added to the end to account for the non-365 day calendar
     def hijri_range
       lambda do |_record, accumulator, _context|
-        return if accumulator.empty?
+        return if accumulator.compact.empty?
 
         accumulator.replace((to_hijri(accumulator.first)..to_hijri(accumulator.last) + 1).to_a)
       end
@@ -114,6 +114,8 @@ module Macros
     # Extracts date range from American University of Cairo data
     def auc_date_range
       lambda do |_record, accumulator, context|
+        return if accumulator.compact.empty?
+
         range_years = []
         accumulator.each do |val|
           range_years << val.scan(AUC_REGEX).map { |year| year.sub(AUC_DELIM, '').to_i }

--- a/lib/macros/field_extraction.rb
+++ b/lib/macros/field_extraction.rb
@@ -13,12 +13,12 @@ module Macros
     }.freeze
     private_constant :NS
 
-    # Extracts value from the first column if available, or the second column if the first is not available.
-    def column_or_other_column(column, second_column) # rubocop:disable Metrics/AbcSize
-      lambda do |row, accumulator, _context|
-        return if row[column].to_s.empty? && row[second_column].to_s.empty?
+    # Extracts value from the field if available, or the default if the field is empty.
+    def extract_field_or_defualt(field, default) # rubocop:disable Metrics/AbcSize
+      lambda do |record, accumulator, _context|
+        return if record[field].to_s.empty? && record[default].to_s.empty?
 
-        result = row[column].to_s.empty? ? Array(row[second_column].to_s) : Array(row[column].to_s)
+        result = record[field].to_s.empty? ? Array(record[default].to_s) : Array(record[field].to_s)
         accumulator.concat(result)
       end
     end

--- a/lib/macros/field_extraction.rb
+++ b/lib/macros/field_extraction.rb
@@ -23,6 +23,16 @@ module Macros
       end
     end
 
+    # Extracts value from the first column if available, or the second column if the first is not available.
+    def column_or_other_column(column, second_column) # rubocop:disable Metrics/AbcSize
+      lambda do |row, accumulator, _context|
+        return if row[column].to_s.empty? && row[second_column].to_s.empty?
+
+        result = row[column].to_s.empty? ? Array(row[second_column].to_s) : Array(row[column].to_s)
+        accumulator.concat(result)
+      end
+    end
+
     # Extracts fields_to_extract from json_list
     def extract_json_list(json_list, field_to_extract)
       lambda do |record, accumulator|

--- a/lib/macros/field_extraction.rb
+++ b/lib/macros/field_extraction.rb
@@ -14,9 +14,9 @@ module Macros
     private_constant :NS
 
     # Extracts value from the field if available, or the default if the field is empty.
-    def extract_field_or_defualt(field, default) # rubocop:disable Metrics/AbcSize
+    def extract_field_or_defualt(field, default)
       lambda do |record, accumulator, _context|
-        return if record[field].to_s.empty? && record[default].to_s.empty?
+        return unless record[field].present? || record[default].present?
 
         result = record[field].to_s.empty? ? Array(record[default].to_s) : Array(record[field].to_s)
         accumulator.concat(result)
@@ -24,9 +24,9 @@ module Macros
     end
 
     # Extracts value from the first column if available, or the second column if the first is not available.
-    def column_or_other_column(column, second_column) # rubocop:disable Metrics/AbcSize
+    def column_or_other_column(column, second_column)
       lambda do |row, accumulator, _context|
-        return if row[column].to_s.empty? && row[second_column].to_s.empty?
+        return unless row[column].present? || row[second_column].present?
 
         result = row[column].to_s.empty? ? Array(row[second_column].to_s) : Array(row[column].to_s)
         accumulator.concat(result)

--- a/lib/macros/normalize_type.rb
+++ b/lib/macros/normalize_type.rb
@@ -22,6 +22,8 @@ module Macros
     # @return [Proc] a proc that traject can call for each record
     def normalize_has_type # rubocop:disable Metrics/MethodLength
       lambda do |_record, accumulator|
+        return if accumulator.compact.empty?
+
         accumulator.map!(&:downcase)
         translation_map = %w[has_type_from_contributor
                              has_type_from_collection

--- a/lib/macros/prepend.rb
+++ b/lib/macros/prepend.rb
@@ -9,8 +9,7 @@ module Macros
     #  to_field 'cho_description', column('scribe'), arabic_script_lang_or_default('ar-Arab', 'en'), return_or_prepend('Scribe: ', 'الكاتب: ')
     def intelligent_prepend(prepend_string_en, prepend_string_translation)
       lambda do |_record, accumulator|
-        return if accumulator.empty?
-        return if accumulator.first.nil?
+        return if accumulator.compact.empty?
 
         accumulator.filter_map { |n| n[:values].map { |s| n[:language] == 'en' ? s.prepend(prepend_string_en) : s.prepend(prepend_string_translation) } }
       end

--- a/lib/macros/prepend.rb
+++ b/lib/macros/prepend.rb
@@ -10,6 +10,7 @@ module Macros
     def intelligent_prepend(prepend_string_en, prepend_string_translation)
       lambda do |_record, accumulator|
         return if accumulator.empty?
+        return if accumulator.first.nil?
 
         accumulator.filter_map { |n| n[:values].map { |s| n[:language] == 'en' ? s.prepend(prepend_string_en) : s.prepend(prepend_string_translation) } }
       end
@@ -21,7 +22,7 @@ module Macros
     #  to_field 'cho_description', column('scribe'), arabic_script_lang_or_default('ar-Arab', 'en'), return_or_prepend('Scribe: ', 'الكاتب: ')
     def dlme_prepend(prepend_string)
       lambda do |_record, accumulator|
-        return if accumulator.empty?
+        return if accumulator.compact.empty?
 
         values = []
         accumulator.each do |val|

--- a/lib/macros/transformation.rb
+++ b/lib/macros/transformation.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Macros
+  # Split helpers for traject mappings
+  module Transformation
+    # Run ruby `gsub` on each value in accumulator, with pattern and replace value given.
+    def dlme_gsub(pattern, replace)
+      lambda do |_rec, acc|
+        return if acc.compact.empty?
+
+        acc.collect! { |v| v.gsub(pattern, replace) }
+      end
+    end
+
+    # Run ruby `split` on each value in the accumulator, with separator
+    # given, flatten all results into single array as accumulator.
+    # Will generally result in more individual values in accumulator as output than were
+    # there in input, as input values are split up into multiple values.
+    def dlme_split(separator)
+      lambda do |_rec, acc|
+        return if acc.compact.empty?
+
+        acc.replace(acc.flat_map { |v| v.split(separator) })
+      end
+    end
+
+    # For each value in accumulator, remove all leading or trailing whitespace
+    # (unique aware). Like ruby #strip, but whitespace-aware
+    #
+    # @example
+    #     to_field "title", extract_marc("245"), strip
+    def dlme_strip
+      lambda do |_rec, acc|
+        return if acc.compact.empty?
+
+        acc.collect! do |v|
+          # unicode whitespace class aware
+          v.sub(/\A[[:space:]]+/, '').sub(/[[:space:]]+\Z/, '')
+        end
+      end
+    end
+  end
+end

--- a/lib/translation_maps/has_type_from_collection.yaml
+++ b/lib/translation_maps/has_type_from_collection.yaml
@@ -23,7 +23,6 @@ auc-rare-books: Books
 auc-saleh-lamei: Drawings
 auc-taxiphote-slides: Photographs
 auc-van-leo-photographs: Photographs
-auc-voice-of-america: Radio Program
 auc-wassef: Drawings
 lau-lebanese-painters: Paintings
 lau-ottoman-embroidery: Embroidery

--- a/lib/translation_maps/lang_from_downcased.yaml
+++ b/lib/translation_maps/lang_from_downcased.yaml
@@ -2,6 +2,7 @@ altaic languages: Altaic Languages
 amharic: Amharic
 arabic: Arabic
 arabic;: Arabic
+arabic in transliteration: Arabic
 aramaic: Aramaic
 aramaic, christian palestinian: Aramaic
 aratur: Aratur
@@ -72,6 +73,7 @@ turkish in arabic script: Turkish, Ottoman (1500-1928)
 turkish (in greek alphabet): Turkish, Karamanli
 turkish, ottoman: Turkish, Ottoman (1500-1928)
 turkish, ottoman (1500-1928): Turkish, Ottoman (1500-1928)
+Turkish, Ottoman (1500-1928): Turkish, Ottoman (1500-1928)
 turkish: Turkish
 undefined ancient south arabian language: Undefined ancient south Arabian language
 urdu: Urdu

--- a/lib/translation_maps/lang_from_errors.yaml
+++ b/lib/translation_maps/lang_from_errors.yaml
@@ -1,4 +1,7 @@
+al-qāhirah: ""
 and arabic.: Arabic # AUC Rare books
+arabi: Arabic # AUC
+"al-qāhirah: muʼassasat dār al-hilāl": ""
 otomian languages: Turkish, Ottoman (1500-1928) # LOC Abdul-Hamid-II Photos
 in arabic: Arabic # AUC Rare books
 in english: English # AUC Rare books
@@ -6,11 +9,12 @@ in french with transcriptions in greek: French # AUC Rare books
 in french with transcriptions in greek, latin, and arabic.: French # AUC Rare books
 in french: French # AUC Rare books
 in german: German # AUC Rare books
-selections from the rare books and special collections library: "" # AUC Rare books
 "ms 639, ms 640, ms 641, ms 642, ms 643, ms 644, ms 645, ms 646, ms 647, ms 648, ms 649, ms 650, ms 651, ms 652, ms 653, ms 654, ms 655, ms 656, ms 658, ms 659, ms 662, ms 663, ms 664, ms 665, ms 668, ms 669 : arabic": Arabic
 "ms 657, ms 661, ms 666, ms 667 : turkish, ottoman": Turkish, Ottoman (1500-1928)
 "ms 660 : persian": Persian
-turkish, ottoman, arabic:
-  - Arabic
-  - Turkish, Ottoman (1500-1928)
+muʼassasat dār al-hilāl: ""
+otomian: Turkish, Ottoman (1500-1928)
+selections from the rare books and special collections library: "" # AUC Rare books
 "ms 607, ms 608, ms 609, ms 610, ms 611, ms 612, ms 613, ms 614, ms 615, ms 616, ms 617, ms 618, ms 619: arabic": Arabic
+selections from the rare books: ""
+special collections library: ""

--- a/spec/lib/contracts/cho_spec.rb
+++ b/spec/lib/contracts/cho_spec.rb
@@ -209,6 +209,82 @@ RSpec.describe Contracts::CHO do
     end
   end
 
+  describe 'cho_edm_type_control_vocab' do
+    %i[
+      cho_edm_type
+    ].each do |field_name|
+      describe field_name do
+        context 'when value in field is in the controlled vocabulary' do
+          let(:cho) do
+            {
+              field_name => {
+                'en' => ['Text']
+              }
+            }
+          end
+
+          it 'has no errors' do
+            expect(contract.errors[field_name]).to be_nil
+          end
+        end
+
+        context 'when value in field is not in the controlled vocabulary' do
+          let(:cho) do
+            {
+              field_name => {
+                'en' => ['book']
+              }
+            }
+          end
+
+          it 'raises an error' do
+            expect(contract.errors[field_name]).to include(
+              'unexpected edm_type value(s) found : book'
+            )
+          end
+        end
+      end
+    end
+  end
+
+  describe 'cho_has_type_control_vocab' do
+    %i[
+      cho_has_type
+    ].each do |field_name|
+      describe field_name do
+        context 'when value in field is in the controlled vocabulary' do
+          let(:cho) do
+            {
+              field_name => {
+                'en' => ['Books']
+              }
+            }
+          end
+
+          it 'has no errors' do
+            expect(contract.errors[field_name]).to be_nil
+          end
+        end
+
+        context 'when value in field is not in the controlled vocabulary' do
+          let(:cho) do
+            {
+              field_name => {
+                'en' => ['text']
+              }
+            }
+          end
+
+          it 'raises an error' do
+            expect(contract.errors[field_name]).to include(
+              'unexpected has_type value(s) found : text'
+            )
+          end
+        end
+      end
+    end
+  end
+
   describe 'singular web resource fields' do
     %i[
       agg_is_shown_at

--- a/spec/lib/traject/macros/field_extraction_spec.rb
+++ b/spec/lib/traject/macros/field_extraction_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe Macros::FieldExtraction do
     end
   end
 
+  describe 'extract_field_or_defualt' do
+    # Sample records
+    let(:both_fields) { { 'title' => 'Some title', 'other' => 'Some other field' } }
+    let(:only_other) { { 'other' => 'Some other field' } }
+
+    before do
+      indexer.instance_eval do
+        to_field 'cho_title', extract_field_or_defualt('title', 'other')
+      end
+    end
+
+    it 'has title present' do
+      expect(indexer.map_record(both_fields)).to eq('cho_title' => ['Some title'])
+    end
+
+    it 'has no title but other field present' do
+      expect(indexer.map_record(only_other)).to eq('cho_title' => ['Some other field'])
+    end
+  end
+
   describe '#xpath_multi_lingual_commas_with_prepend' do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:ar_val_only_record) do
       <<-XML

--- a/spec/lib/traject/macros/transformation_spec.rb
+++ b/spec/lib/traject/macros/transformation_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'macros/transformation'
+
+RSpec.describe Macros::Transformation do
+  let(:klass) do
+    Class.new do
+      include Macros::Transformation
+      include TrajectPlus::Macros
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe '#dlme_gsub' do
+    context 'when pattern in string' do
+      let(:output) { ['http://value'] }
+
+      it 'substitutes the replacement for the pattern' do
+        callable = instance.dlme_gsub('http://', 'dlme-id-')
+        expect(callable.call(nil, output)).to eq(['dlme-id-value'])
+      end
+    end
+
+    context 'when pattern not in string' do
+      let(:output) { ['value'] }
+
+      it 'leaves the string as is' do
+        callable = instance.dlme_gsub('http://', '')
+        expect(callable.call(nil, output)).to eq(['value'])
+      end
+    end
+  end
+
+  describe '#dlme_split' do
+    context 'when pattern in string' do
+      let(:output) { ['value: other_value'] }
+
+      it 'splits the string into a list on the split pattern' do
+        callable = instance.dlme_split(':')
+        expect(callable.call(nil, output)).to eq(['value', ' other_value'])
+      end
+    end
+
+    context 'when pattern not in string' do
+      let(:output) { ['value'] }
+
+      it 'prepends the prepend string' do
+        callable = instance.dlme_split(':')
+        expect(callable.call(nil, output)).to eq(['value'])
+      end
+    end
+  end
+
+  describe '#dlme_strip' do
+    context 'when trailing whitespace in string' do
+      let(:output) { ['value '] }
+
+      it 'removes the whitespace' do
+        callable = instance.dlme_strip
+        expect(callable.call(nil, output)).to eq(['value'])
+      end
+    end
+
+    context 'when leading whitespace in string' do
+      let(:output) { [' value'] }
+
+      it 'removes the whitespace' do
+        callable = instance.dlme_strip
+        expect(callable.call(nil, output)).to eq(['value'])
+      end
+    end
+
+    context 'when extra whitespace in middle of string' do
+      let(:output) { ['value   value'] }
+
+      it 'does not remove the whitespace' do
+        callable = instance.dlme_strip
+        expect(callable.call(nil, output)).to eq(['value   value'])
+      end
+    end
+  end
+end

--- a/traject_configs/auc.rb
+++ b/traject_configs/auc.rb
@@ -13,6 +13,7 @@ require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/path_to_file'
 require 'macros/prepend'
+require 'macros/transformation'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
@@ -31,133 +32,137 @@ extend Macros::NormalizeType
 extend Macros::PathToFile
 extend Macros::Prepend
 extend Macros::StringHelper
+extend Macros::Transformation
 extend Macros::Timestamp
 extend Macros::TitleExtraction
 extend Macros::Version
 extend TrajectPlus::Macros
-extend TrajectPlus::Macros::Csv
+extend TrajectPlus::Macros::JSON
 
 settings do
+  provide 'allow_duplicate_values', false
+  provide 'allow_nil_values', false
+  provide 'allow_empty_fields', false
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
-  provide 'reader_class_name', 'TrajectPlus::CsvReader'
+  provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), translation_map('agg_collection_from_provider_id'), lang('en')
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-')
 
 # File path
-to_field 'dlme_source_file', path_to_file, split('/'), at_index(3)
+to_field 'dlme_source_file', path_to_file, dlme_split('/'), at_index(3)
 
 # Cho Required
-to_field 'id', column('id'), parse_csv, strip, gsub('/manifest.json', ''), gsub('https://cdm15795.contentdm.oclc.org/iiif/', '')
-to_field 'cho_title', column('title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_title', column('title-arabic'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_title', column('title-english'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'id', extract_json('..id'), dlme_gsub('/manifest.json', ''), dlme_gsub('https://cdm15795.contentdm.oclc.org/iiif/', '')
+to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Cho Other
-to_field 'cho_alternative', column('alternative-title'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_alternative', column('title-alternative'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_contributor', column('collector'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Collector: ', 'جامع: ')
-to_field 'cho_contributor', column('compiler'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Compiler: ', 'مترجم: ')
-to_field 'cho_contributor', column('contributor'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_contributor', column('scribe'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scribe: ', 'الكاتب: ')
-to_field 'cho_coverage', column('coverage'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_creator', column('architect'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architect: ', 'مهندس معماري: ')
-to_field 'cho_creator', column('artist'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Artist: ', 'فنان: ')
-to_field 'cho_creator', column('author'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Author: ', 'مؤلف: ')
-to_field 'cho_creator', column('creator'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_creator', column('creator-arabic'), parse_csv, strip, lang('ar-Arab')
-to_field 'cho_creator', column('creator-alternative'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_creator', column('creator-english'), parse_csv, strip, lang('en')
-to_field 'cho_creator', column('photographer'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Photographer: ', 'مصور فوتوغرافي: ')
-to_field 'cho_date', column('date'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_hijri', column('date'), parse_csv, strip, auc_date_range, hijri_range
-to_field 'cho_date_range_norm', column('date'), parse_csv, strip, auc_date_range
-to_field 'cho_date', column('date-built'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_hijri', column('date-built'), parse_csv, strip, auc_date_range, hijri_range
-to_field 'cho_date_range_norm', column('date-built'), parse_csv, strip, auc_date_range
-to_field 'cho_date', column('date-created'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_hijri', column('date-created'), parse_csv, strip, auc_date_range, hijri_range
-to_field 'cho_date_range_norm', column('date-created'), parse_csv, strip, auc_date_range
-to_field 'cho_dc_rights', column('license'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_dc_rights', column('access-rights'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_dc_rights', column('rights'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('architectural-detail'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
-to_field 'cho_description', column('dimensions-of-original'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Dimensions of original: ', 'أبعاد الأصل: ')
-to_field 'cho_description', column('dimensions-of-printed-material'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Dimensions of print: ', 'تقنية: ')
-to_field 'cho_description', column('description'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('description-arabic'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('description-english'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('note'), parse_csv, strip, prepend('Note: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('photo-term'), parse_csv, strip, prepend('Photo type: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('printed-material'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', column('scale'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
-to_field 'cho_description', column('sheet-scale'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
-to_field 'cho_description', column('style-period'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Style period: ', 'فترة النمط: ')
-to_field 'cho_description', column('technical-details-of-original-drawing'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technical details: ', 'تفاصيل تقنية: ')
-to_field 'cho_description', column('technique-of-paper-drawing'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technique: ', 'أبعاد الطباعة: ')
-to_field 'cho_edm_type', column('genre'), parse_csv, strip, normalize_has_type, normalize_edm_type, lang('en')
-to_field 'cho_edm_type', column('genre'), parse_csv, strip, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_edm_type', column('genre-aat'), parse_csv, strip, normalize_has_type, normalize_edm_type, lang('en')
-to_field 'cho_edm_type', column('genre-aat'), parse_csv, strip, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_edm_type', column('getty-aat'), parse_csv, strip, normalize_has_type, normalize_edm_type, lang('en')
-to_field 'cho_edm_type', column('getty-aat'), parse_csv, strip, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_edm_type', column('type'), parse_csv, strip, normalize_has_type, normalize_edm_type, lang('en')
-to_field 'cho_edm_type', column('type'), parse_csv, strip, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), normalize_has_type, normalize_edm_type, lang('en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), translation_map('edm_type_from_collection'), lang('en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), translation_map('edm_type_from_collection'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_extent', column('extent'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_extent', column('size-in-cm'), parse_csv, strip, prepend('Size in cm: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_format', column('format'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_alternative', extract_json('..alternative-title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_alternative', extract_json('..title-alternative'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_contributor', extract_json('..collector'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Collector: ', 'جامع: ')
+to_field 'cho_contributor', extract_json('..compiler'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Compiler: ', 'مترجم: ')
+to_field 'cho_contributor', extract_json('..contributor'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_contributor', extract_json('..scribe'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scribe: ', 'الكاتب: ')
+to_field 'cho_coverage', extract_json('..coverage'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('..architect'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architect: ', 'مهندس معماري: ')
+to_field 'cho_creator', extract_json('..artist'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Artist: ', 'فنان: ')
+to_field 'cho_creator', extract_json('..author'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Author: ', 'مؤلف: ')
+to_field 'cho_creator', extract_json('..creator'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('..creator-arabic'), flatten_array, lang('ar-Arab')
+to_field 'cho_creator', extract_json('..creator-alternative'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('..creator-english'), flatten_array, lang('en')
+to_field 'cho_creator', extract_json('..photographer'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Photographer: ', 'مصور فوتوغرافي: ')
+to_field 'cho_date', extract_json('..date'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_hijri', extract_json('..date'), flatten_array, auc_date_range, hijri_range
+to_field 'cho_date_range_norm', extract_json('..date'), flatten_array, auc_date_range
+to_field 'cho_date', extract_json('..date-built'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_hijri', extract_json('..date-built'), flatten_array, auc_date_range, hijri_range
+to_field 'cho_date_range_norm', extract_json('..date-built'), flatten_array, auc_date_range
+to_field 'cho_date', extract_json('..date-created'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_hijri', extract_json('..date-created'), flatten_array, auc_date_range, hijri_range
+to_field 'cho_date_range_norm', extract_json('..date-created'), flatten_array, auc_date_range
+to_field 'cho_dc_rights', extract_json('..license'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_dc_rights', extract_json('..access-rights'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_dc_rights', extract_json('..rights'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..architectural-detail'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
+to_field 'cho_description', extract_json('..dimensions-of-original'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Dimensions of original: ', 'أبعاد الأصل: ')
+to_field 'cho_description', extract_json('..dimensions-of-printed-material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Dimensions of print: ', 'تقنية: ')
+to_field 'cho_description', extract_json('..description'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..description-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..description-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..note'), flatten_array, dlme_prepend('Note: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..photo-term'), flatten_array, dlme_prepend('Photo type: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..printed-material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..scale'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
+to_field 'cho_description', extract_json('..sheet-scale'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
+to_field 'cho_description', extract_json('..style-period'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Style period: ', 'فترة النمط: ')
+to_field 'cho_description', extract_json('..technical-details-of-original-drawing'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technical details: ', 'تفاصيل تقنية: ')
+to_field 'cho_description', extract_json('..technique-of-paper-drawing'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technique: ', 'أبعاد الطباعة: ')
+to_field 'cho_edm_type', extract_json('..genre'), flatten_array, normalize_has_type, normalize_edm_type, lang('en')
+to_field 'cho_edm_type', extract_json('..genre'), flatten_array, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', extract_json('..genre-aat'), flatten_array, normalize_has_type, normalize_edm_type, lang('en')
+to_field 'cho_edm_type', extract_json('..genre-aat'), flatten_array, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', extract_json('..getty-aat'), flatten_array, normalize_has_type, normalize_edm_type, lang('en')
+to_field 'cho_edm_type', extract_json('..getty-aat'), flatten_array, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', extract_json('..type'), flatten_array, normalize_has_type, normalize_edm_type, lang('en')
+to_field 'cho_edm_type', extract_json('..type'), flatten_array, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), normalize_has_type, normalize_edm_type, lang('en')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), translation_map('edm_type_from_collection'), lang('en')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), translation_map('edm_type_from_collection'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_extent', extract_json('..extent'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_extent', extract_json('..size-in-cm'), flatten_array, dlme_prepend('Size in cm: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_format', extract_json('..format'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 # Using collection identifier to map to has type since type values are vague
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), normalize_has_type, lang('en')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('auc-'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', column('genre'), parse_csv, strip, normalize_has_type, lang('en')
-to_field 'cho_has_type', column('genre'), parse_csv, strip, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', column('genre-aat'), parse_csv, strip, normalize_has_type, lang('en')
-to_field 'cho_has_type', column('genre-aat'), parse_csv, strip, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', column('getty-aat'), parse_csv, strip, normalize_has_type, lang('en')
-to_field 'cho_has_type', column('getty-aat'), parse_csv, strip, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', column('physical-format'), parse_csv, strip, normalize_has_type, lang('en')
-to_field 'cho_has_type', column('physical-format'), parse_csv, strip, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', column('type'), parse_csv, strip, normalize_has_type, lang('en')
-to_field 'cho_has_type', column('type'), parse_csv, strip, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_identifier', column('call-number'), parse_csv, strip
-to_field 'cho_identifier', column('identifier'), parse_csv, strip
-to_field 'cho_identifier', column('object-identifier'), parse_csv, strip
-to_field 'cho_identifier', column('original-identifier'), parse_csv, strip
-to_field 'cho_is_part_of', column('collection'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_is_part_of', column('digital-collection'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_is_part_of', column('relation'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_language', column('language'), parse_csv, split(';'), strip, split(','), strip, gsub('\\r', ''), gsub('\\n', ''), gsub('\r', ''), gsub('\n', ''), normalize_language, lang('en')
-to_field 'cho_language', column('language'), parse_csv, split(';'), strip, split(','), strip, gsub('\\r', ''), gsub('\\n', ''), gsub('\r', ''), gsub('\n', ''), normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_language', column('languages'), parse_csv, split(';'), strip, split(','), strip, gsub('\\r', ''), gsub('\\n', ''), gsub('\r', ''), gsub('\n', ''), normalize_language, lang('en')
-to_field 'cho_language', column('languages'), parse_csv, split(';'), strip, split(','), strip, gsub('\\r', ''), gsub('\\n', ''), gsub('\r', ''), gsub('\n', ''), normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_provenance', column('provenance'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_publisher', column('publisher'), parse_csv, strip, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_medium', column('medium'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_spatial', column('coverage-spatial/note'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_spatial', column('location'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_spatial', column('location-arabic'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_spatial', column('location-english'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('keyword'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('site'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('subject'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('subject-lcsh'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('subject-tgm'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', column('topic'), parse_csv, split(';'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_temporal', column('date-beginning'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_type', column('genre'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_type', column('genre-aat'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_type', column('getty-aat'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_type', column('type'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_type', column('worktype-of-printed-material'), parse_csv, strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), normalize_has_type, lang('en')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('..genre'), flatten_array, normalize_has_type, lang('en')
+to_field 'cho_has_type', extract_json('..genre'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('..genre-aat'), flatten_array, normalize_has_type, lang('en')
+to_field 'cho_has_type', extract_json('..genre-aat'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('..getty-aat'), flatten_array, normalize_has_type, lang('en')
+to_field 'cho_has_type', extract_json('..getty-aat'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('..physical-format'), flatten_array, normalize_has_type, lang('en')
+to_field 'cho_has_type', extract_json('..physical-format'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', extract_json('..type'), flatten_array, normalize_has_type, lang('en')
+to_field 'cho_has_type', extract_json('..type'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', extract_json('..call-number'), flatten_array
+to_field 'cho_identifier', extract_json('..identifier'), flatten_array
+to_field 'cho_identifier', extract_json('..object-identifier'), flatten_array
+to_field 'cho_identifier', extract_json('..original-identifier'), flatten_array
+to_field 'cho_is_part_of', extract_json('..collection'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_is_part_of', extract_json('..digital-collection'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_is_part_of', extract_json('..relation'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_language', extract_json('..language'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('..language'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_language', extract_json('..languages'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('..languages'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_provenance', extract_json('..provenance'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_publisher', extract_json('..publisher'), flatten_array, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_medium', extract_json('..medium'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..coverage-spatial/note'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..keyword'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..site'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject'), flatten_array, dlme_split(';'), unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-lcsh'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-tgm'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..topic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_temporal', extract_json('..date-beginning'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('..genre'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('..genre-aat'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('..getty-aat'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('..type'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('..worktype-of-printed-material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -169,18 +174,18 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_dc_rights' => [literal('To inquire about permissions or reproductions, contact the Rare Books and Special Collections Library, The American University in Cairo at +20.2.2615.3676 or rbscl-ref@aucegypt.edu.')],
-    'wr_format' => [column('iiif_format'), parse_csv, at_index(0)],
-    'wr_id' => [column_or_other_column('resource', 'identifier'), parse_csv],
-    'wr_is_referenced_by' => [column('id'), parse_csv, at_index(0)]
+    'wr_format' => [extract_json('..iiif_format'), flatten_array, at_index(0)],
+    'wr_id' => [extract_field_or_defualt('resource', 'identifier'), flatten_array, at_index(0)],
+    'wr_is_referenced_by' => [extract_json('..id'), flatten_array, at_index(0)]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_dc_rights' => [literal('To inquire about permissions or reproductions, contact the Rare Books and Special Collections Library, The American University in Cairo at +20.2.2615.3676 or rbscl-ref@aucegypt.edu.')],
-    'wr_format' => [column('iiif_format'), parse_csv, at_index(0)],
-    'wr_id' => [column('resource'), parse_csv, gsub('/full/full/0/default.jpg', '/full/400,400/0/default.jpg'), default('https://www.aucegypt.edu/sites/default/files/2019-05/auclogo_0.png')],
-    'wr_is_referenced_by' => [column('id'), parse_csv, at_index(0)]
+    'wr_format' => [extract_json('..iiif_format'), flatten_array, at_index(0)],
+    'wr_id' => [extract_json('..resource'), flatten_array, at_index(0), dlme_gsub('/full/full/0/default.jpg', '/full/400,400/0/default.jpg')],
+    'wr_is_referenced_by' => [extract_json('..id'), flatten_array, at_index(0)]
   )
 end
 to_field 'agg_provider_country', provider_country, lang('en')


### PR DESCRIPTION
## Why was this change made?

AUC was still using csv data and needed to switch to json. The json records contain nil values which causes, `strip`, `gsub`, `prepend`, etc. to fail. This adds new versions of those macros that guard against that. We are also seeing some errors with the values that get into `cho_edm_type` and `cho_has_type` so this treats those values as a controlled vocabulary and raises an error when a value not in the list is found. I'm planning a follow up PR to add nil-safe versions of all of the rest of the macros in https://github.com/traject/traject/blob/main/lib/traject/macros/transformation.rb. But this will require moving some things around and updating all of the configs that use them. Also planning another PR to remove all of the xml and csv macros that we no longer need.


## How was this change tested?

Local transform, and new tests.

## Which documentation and/or configurations were updated?

n/a

