### PR TITLE
Ensure no nils are used when subbing

### DIFF
--- a/lib/macros/transformation.rb
+++ b/lib/macros/transformation.rb
@@ -54,7 +54,8 @@ module Macros
     #     to_field "title", extract_marc("245"), strip
     def dlme_strip
       lambda do |_rec, acc|
-        return if acc.compact.empty?
+        acc.compact! # remove any nils
+        return if acc.empty?
 
         acc.collect! do |v|
           # unicode whitespace class aware


### PR DESCRIPTION
## Why was this change made?

Ensure that `nil` values are removed from the accumulator to avoid raising errors unexpectedly when `dlme_strip` is used


## How was this change tested?



## Which documentation and/or configurations were updated?



