### PR TITLE
change file path index for collection id

### DIFF
--- a/traject_configs/penn_museum.rb
+++ b/traject_configs/penn_museum.rb
@@ -45,9 +45,9 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), lang('en')
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('penn-museum-')
+to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(4), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(4), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(4), gsub('_', '-'), prepend('penn-museum-')
 
 # File path
 to_field 'dlme_source_file', path_to_file


### PR DESCRIPTION
## Why was this change made?

The file path in Airflow seems to have changed. I used to select the select the collection name with `to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2)` and now I need `to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(4)`. This seems to work but other collections may need to be updated.

## How was this change tested?

Local transform

## Which documentation and/or configurations were updated?

n/a

