### PR TITLE
clean up some issues with path_to_file

### DIFF
--- a/lib/macros/path_to_file.rb
+++ b/lib/macros/path_to_file.rb
@@ -9,7 +9,7 @@ module Macros
     # @return [Proc] a proc that traject can call for each record
     def path_to_file
       lambda do |_, accumulator, context|
-        accumulator << File.join(Pathname(context.input_name)).gsub('/opt/airflow/working', '')
+        accumulator << File.join(Pathname(context.input_name)).gsub('/opt/airflow/working', '').gsub('//', '/')
       end
     end
   end

--- a/traject_configs/auc.rb
+++ b/traject_configs/auc.rb
@@ -55,7 +55,7 @@ to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index
 to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-')
 
 # File path
-to_field 'dlme_source_file', path_to_file, dlme_split('/'), at_index(3)
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id', extract_json('..id'), dlme_gsub('/manifest.json', ''), dlme_gsub('https://cdm15795.contentdm.oclc.org/iiif/', '')

--- a/traject_configs/penn_museum.rb
+++ b/traject_configs/penn_museum.rb
@@ -53,7 +53,7 @@ to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_in
 to_field 'dlme_source_file', path_to_file
 
 # CHO Required
-to_field 'id', extract_json('emuIRN'), flatten_array, transform(&:to_s), dlme_prepend('penn-egyptian-')
+to_field 'id', extract_json('emuIRN'), flatten_array, transform(&:to_s), dlme_prepend('penn-museum-')
 to_field 'cho_title', extract_json('.object_name'), flatten_array, dlme_default('Untitled'), dlme_split('|'), lang('en')
 
 # CHO Other

--- a/traject_configs/penn_museum.rb
+++ b/traject_configs/penn_museum.rb
@@ -45,9 +45,9 @@ end
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
 
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(4), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), lang('en')
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(4), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(4), gsub('_', '-'), prepend('penn-museum-')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(2), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(2), gsub('_', '-'), prepend('penn-museum-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_index(2), gsub('_', '-'), prepend('penn-museum-')
 
 # File path
 to_field 'dlme_source_file', path_to_file


### PR DESCRIPTION
## Why was this change made?

For some reason, some values returned from `path_to_file` have `//` which causes issues when we use `path_to_file` to build the collection name.

## How was this change tested?

Local transform

## Which documentation and/or configurations were updated?

n/a

