### PR TITLE
updates some configs to ensure we are mapping or intentionally ignori…

### DIFF
--- a/lib/translation_maps/agg_collection_ar_from_en.yaml
+++ b/lib/translation_maps/agg_collection_ar_from_en.yaml
@@ -21,6 +21,7 @@ Ancient Art (Walters): الفن القديم (والترز)
 Ancient Egyptian Paintings (AUC): اللوحات المصرية القديمة (الجامعة الأمريكية بالقاهرة)
 Ancient Near Eastern Art (The Met): فن الشرق الأدنى القديم (متحف متروبوليتان للفنون)
 Antiquities Coalition: تحالف الآثار
+Archaeological Artifacts at Sakıp Sabancı Museum: التحف الأثرية في متحف ساكيب سابانجي
 Arab Image Foundation Photo Negatives (UCLA): المؤسسة العربية للصورة الصور السلبية (جامعة كاليفورنيا، لوس أنجلوس)
 Arabic Books Collection (AUC): مجموعة الكتب العربية (الجامعة الأمريكية بالقاهرة)
 Arabic Collections Online (AUB): المجموعات العربية على الإنترنت (الجامعة الأمريكية في بيروت)
@@ -49,6 +50,7 @@ Caro Minasian Collection of Armenian Material, circa 1600-1968 (UCLA): مجمو�
 CLUSTER: CLUSTER
 Consejo Superior de Investigaciones Científicas (CSIC): المجلس الأعلى للبحث العلمي
 David Rumsey Map Collectoion (Stanford): مجموعة خرائط ديفيد رمزي (ستانفورد)
+Decorative Furniture at Sakıp Sabancı Museum: الأثاث المزخرف في متحف ساكيب سابانجي
 Digital Archive for the Study of pre-Islamic Arabian Inscriptions: الأرشيف الرقمي لدراسة النقوش العربية قبل الإسلام
 East Asian Art (Walters): فن شرق آسيا (والترز)
 Egypt Artist Oral Histories and Archives (AUC): التاريخ الشفوي والأرشيف للفنانين المصريين (الجامعة الأمريكية بالقاهرة)
@@ -71,6 +73,7 @@ Hebrew Manuscripts at the Bodleian: المخطوطات العبرية في بو�
 Historic Cairo Architectural Mapping (UCLA): رسم الخرائط المعمارية التاريخية للقاهرة (جامعة كاليفورنيا، لوس أنجلوس)
 Historical Magazines (AUC): مجلات تاريخية (الجامعة الأمريكية بالقاهرة)
 Historical Maps (AUC): الخرائط التاريخية
+Hüseyin Avni Lifij (1886-1927) Collection at Sakıp Sabancı Museum: مجموعة حسين أفني ليفيج (1886-1927) في متحف ساكيب سابانجي
 IFPO Images: الأرشيفات المفتوحة للمعهد الفرنسي لصور الشرق الأدنى
 Images from 35mm Slides and Filmstrips at the Bodleian Library: صور مأخوذة من شرائح وشرائط أفلام مقاس ٣٥ مم في مكتبة بودليان
 Incunabula and Blockbooks at the Bodleian Library: كتب مطبوعة مبكرة في مكتبة بودليان

--- a/lib/translation_maps/agg_collection_from_provider_id.yaml
+++ b/lib/translation_maps/agg_collection_from_provider_id.yaml
@@ -128,8 +128,11 @@ princeton-posters: Arabic Movie Posters (Princeton)
 princeton-shahnameh: Peck Shahnameh (Princeton)
 qnl: Gulf Records (British Library)
 shahre-farang: Shahre Farang
-ssm-abidindino: Abidin Dino Archive at Sakıp Sabancı Museum
+ssm-abidin-dino: Abidin Dino Archive at Sakıp Sabancı Museum
+ssm-avni-lifij: Hüseyin Avni Lifij (1886-1927) Collection at Sakıp Sabancı Museum
+ssm-archaeological-artifacts: Archaeological Artifacts at Sakıp Sabancı Museum
 ssm-emirgan: Emirgan Archive at Sakıp Sabancı Museum
+ssm-furniture: Decorative Furniture at Sakıp Sabancı Museum
 ssm-kitap-vehat: The Arts of the Book and Calligraphy at Sakıp Sabancı Museum
 ssm-resim-klksyn: Painting Collection at Sakıp Sabancı Museum
 stanford-maps: David Rumsey Map Collectoion (Stanford)
@@ -147,7 +150,7 @@ ucla-iranian-bahai-archives: Iranian National Bahá'í Archives (UCLA)
 ucla-kirkuk-mosque: Kirkuk’s Great Sufi Mosque (UCLA)
 ucla-kurdish-referendum: Kurdish Referendum for Independence (UCLA)
 ucla-mena: Middle East & North Africa Collections (UCLA)
-ucla-minasian-armenian: Caro Minasian Collection of Armenian Material, circa 1600-1968 (UCLA)
+ucla-minasian-armenian-collection: Caro Minasian Collection of Armenian Material, circa 1600-1968 (UCLA)
 ucla-minasian-manuscript-collection: Minasian (Caro) Collection of Persian and Arabic Manuscripts (UCLA)
 ucla-mosul-lives: Mosul Lives (UCLA)
 ucla-near-east-mss: Exhibit Collection of Near Eastern Manuscripts, 1492-1848 (UCLA)

--- a/lib/translation_maps/lang_from_iso_639-2.yaml
+++ b/lib/translation_maps/lang_from_iso_639-2.yaml
@@ -50,6 +50,7 @@ syr: Syriac
 tam: Tamil
 tat: Tatar
 tgk: Tajik
+tuk: Turkmen
 tur: Turkish
 tut: Altaic languages
 urd: Urdu

--- a/traject_configs/aub.rb
+++ b/traject_configs/aub.rb
@@ -108,6 +108,9 @@ to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 
+# Ignored Fields
+## none
+
 each_record convert_to_language_hash(
   'agg_data_provider',
   'agg_data_provider_collection',

--- a/traject_configs/auc.rb
+++ b/traject_configs/auc.rb
@@ -60,9 +60,13 @@ to_field 'dlme_source_file', path_to_file
 # Cho Required
 to_field 'id', extract_json('..id'), dlme_gsub('/manifest.json', ''), dlme_gsub('https://cdm15795.contentdm.oclc.org/iiif/', '')
 to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_title', extract_json('..title-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-by-creator'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', extract_json('..title-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-french'), flatten_array, lang('fr')
+to_field 'cho_title', extract_json('..title-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', extract_json('..title-arabic-العنوان'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-inscribed'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', extract_json('..title-transliteration'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Cho Other
@@ -82,6 +86,7 @@ to_field 'cho_creator', extract_json('..creator-arabic-alternative'), flatten_ar
 to_field 'cho_creator', extract_json('..creator-alternative'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_creator', extract_json('..creator-english'), flatten_array, lang('en')
 to_field 'cho_creator', extract_json('..creator-english-alternative'), flatten_array, lang('en')
+to_field 'cho_creator', extract_json('..creator-transliteration'), flatten_array, lang('en')
 to_field 'cho_creator', extract_json('..photographer'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Photographer: ', 'مصور فوتوغرافي: ')
 to_field 'cho_date', extract_json('..date'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_date_range_hijri', extract_json('..date'), flatten_array, auc_date_range, hijri_range
@@ -95,6 +100,7 @@ to_field 'cho_date_range_norm', extract_json('..date-created'), flatten_array, a
 to_field 'cho_dc_rights', extract_json('..license'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_dc_rights', extract_json('..access-rights'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_dc_rights', extract_json('..rights'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..annotation'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Annotation: ', 'تعليق توضيحي: ')
 to_field 'cho_description', extract_json('..architectural-detail'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
 to_field 'cho_description', extract_json('..architectural-detail-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
 to_field 'cho_description', extract_json('..architectural-detail-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
@@ -103,11 +109,15 @@ to_field 'cho_description', extract_json('..dimensions-of-printed-material'), fl
 to_field 'cho_description', extract_json('..description'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_description', extract_json('..description-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_description', extract_json('..description-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', extract_json('..photo-term'), flatten_array, dlme_prepend('Photo type: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..inscription'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Inscription: ', 'النقش: ')
+to_field 'cho_description', extract_json('..notes'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Notes: ', 'ملحوظات: ')
+to_field 'cho_description', extract_json('..material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Material: ', 'مادة: ')
+to_field 'cho_description', extract_json('..photo-term'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Photo type: ', 'نوع الصورة: ')
 to_field 'cho_description', extract_json('..printed-material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_description', extract_json('..scale'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
 to_field 'cho_description', extract_json('..sheet-scale'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
 to_field 'cho_description', extract_json('..style-period'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Style period: ', 'فترة النمط: ')
+to_field 'cho_description', extract_json('..technique'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technique: ', 'أبعاد الطباعة: ')
 to_field 'cho_description', extract_json('..technical-details-of-original-drawing'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technical details: ', 'تفاصيل تقنية: ')
 to_field 'cho_description', extract_json('..technique-of-paper-drawing'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technique: ', 'أبعاد الطباعة: ')
 to_field 'cho_edm_type', extract_json('..genre'), flatten_array, normalize_has_type, normalize_edm_type, lang('en')
@@ -123,8 +133,11 @@ to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('
 to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), translation_map('edm_type_from_collection'), lang('en')
 to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), translation_map('edm_type_from_collection'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('..extent'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_extent', extract_json('..size-in-cm'), flatten_array, dlme_prepend('Size in cm: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_extent', extract_json('..extent-in-cm'), flatten_array, dlme_prepend('Size in cm: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_extent', extract_json('..size-in-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..size-h--x--w-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..size-h-x-w-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..extent-in-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..measurements-h-x-w-in-cm-without-frame'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Measurements without frame (cm): ', 'القياسات بدون إطار (سم): ')
 to_field 'cho_format', extract_json('..format'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 # Using collection identifier to map to has type since type values are vague
 to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('auc-'), normalize_has_type, lang('en')
@@ -140,6 +153,7 @@ to_field 'cho_has_type', extract_json('..physical-format'), flatten_array, norma
 to_field 'cho_has_type', extract_json('..type'), flatten_array, normalize_has_type, lang('en')
 to_field 'cho_has_type', extract_json('..type'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('..call-number'), flatten_array
+to_field 'cho_identifier', extract_json('..contentdm-number'), flatten_array
 to_field 'cho_identifier', extract_json('..identifier'), flatten_array
 to_field 'cho_identifier', extract_json('..object-identifier'), flatten_array
 to_field 'cho_identifier', extract_json('..original-identifier'), flatten_array
@@ -152,8 +166,10 @@ to_field 'cho_language', extract_json('..language'), flatten_array, dlme_split('
 to_field 'cho_language', extract_json('..languages'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('..languages'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
 to_field 'cho_provenance', extract_json('..provenance'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('..source-donation-note'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_publisher', extract_json('..publisher'), flatten_array, translation_map('lang_ar_from_en'), lang('ar-Arab')
 to_field 'cho_medium', extract_json('..medium'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_related', extract_json('..united-nations-record'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_spatial', extract_json('..coverage-spatialnote'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_spatial', extract_json('..location'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_spatial', extract_json('..location-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
@@ -167,16 +183,24 @@ to_field 'cho_spatial', extract_json('..location-governorate-arabic'), flatten_a
 to_field 'cho_spatial', extract_json('..location-governorate-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_spatial', extract_json('..location-governorate-transliteration'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_spatial', extract_json('..location-governorate-arabic-alternative'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', extract_json('..keyword'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', extract_json('..site'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', extract_json('..subject'), flatten_array, dlme_split(';'), unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..site'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..site-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..site-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..keyword'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Keywords: ', 'الكلمات الرئيسية: ')
+to_field 'cho_subject', extract_json('..keywords'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Keywords: ', 'الكلمات الرئيسية: ')
+to_field 'cho_subject', extract_json('..subject'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-aat'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject-lc'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject-lcsh'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+# subject-lcsh-arabic is not present in harvested data, presumabely because subject-lchs-arabic is present and its a typo. Leaving
+# subject-lcsh-arabic for future proofing, becuaset they will eventually fix the error.
 to_field 'cho_subject', extract_json('..subject-lcsh-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject-lchs-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject-tgm'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', extract_json('..topic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..topic-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..topic-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_temporal', extract_json('..date-beginning'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_type', extract_json('..genre'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_type', extract_json('..genre-aat'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
@@ -214,6 +238,41 @@ to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## edition
+## egyptian-national?
+## gender
+## link-to-catalogue
+## relationship-to-auc
+## subseries-english
+## age
+## plate-number
+## profile
+## acknowledgements
+## published-in
+## description-of-plate
+## coordinated-longitude
+## titles-new
+## repository
+## project-type
+## series
+## nationality
+## source
+## link-to-catalog
+## name
+## state-edition
+## date-submitted
+## source-donation
+## acknowledgments
+## occupation
+## subseries-arabic
+## coordinates-latitude
+## substance
+## contentdm-file-name
+## patron
+## context
+## size
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/auc_serials.rb
+++ b/traject_configs/auc_serials.rb
@@ -32,9 +32,9 @@ extend Macros::NormalizeType
 extend Macros::PathToFile
 extend Macros::Prepend
 extend Macros::StringHelper
-extend Macros::Transformation
 extend Macros::Timestamp
 extend Macros::TitleExtraction
+extend Macros::Transformation
 extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
@@ -61,38 +61,134 @@ to_field 'dlme_project', literal('dlme-serials')
 # Cho Required
 to_field 'id', extract_json('..id'), dlme_gsub('/manifest.json', ''), dlme_gsub('https://cdm15795.contentdm.oclc.org/iiif/', '')
 to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_title', extract_json('..title-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-by-creator'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_title', extract_json('..title-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-french'), flatten_array, lang('fr')
+to_field 'cho_title', extract_json('..title-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-arabic-العنوان'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-inscribed'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_title', extract_json('..title-transliteration'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Cho Other
+to_field 'cho_alternative', extract_json('..alternative-title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_alternative', extract_json('..title-alternative'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_contributor', extract_json('..collector'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Collector: ', 'جامع: ')
+to_field 'cho_contributor', extract_json('..compiler'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Compiler: ', 'مترجم: ')
+to_field 'cho_contributor', extract_json('..contributor'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_contributor', extract_json('..scribe'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scribe: ', 'الكاتب: ')
 to_field 'cho_coverage', extract_json('..coverage'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('..architect'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architect: ', 'مهندس معماري: ')
+to_field 'cho_creator', extract_json('..artist'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Artist: ', 'فنان: ')
+to_field 'cho_creator', extract_json('..author'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Author: ', 'مؤلف: ')
 to_field 'cho_creator', extract_json('..creator'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('..creator-arabic'), flatten_array, lang('ar-Arab')
+to_field 'cho_creator', extract_json('..creator-arabic-alternative'), flatten_array, lang('ar-Arab')
+to_field 'cho_creator', extract_json('..creator-alternative'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_creator', extract_json('..creator-english'), flatten_array, lang('en')
+to_field 'cho_creator', extract_json('..creator-english-alternative'), flatten_array, lang('en')
+to_field 'cho_creator', extract_json('..creator-transliteration'), flatten_array, lang('en')
+to_field 'cho_creator', extract_json('..photographer'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Photographer: ', 'مصور فوتوغرافي: ')
 to_field 'cho_date', extract_json('..date'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_date_range_hijri', extract_json('..date'), flatten_array, auc_date_range, hijri_range
 to_field 'cho_date_range_norm', extract_json('..date'), flatten_array, auc_date_range
+to_field 'cho_date', extract_json('..date-built'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_hijri', extract_json('..date-built'), flatten_array, auc_date_range, hijri_range
+to_field 'cho_date_range_norm', extract_json('..date-built'), flatten_array, auc_date_range
+to_field 'cho_date', extract_json('..date-created'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_hijri', extract_json('..date-created'), flatten_array, auc_date_range, hijri_range
+to_field 'cho_date_range_norm', extract_json('..date-created'), flatten_array, auc_date_range
 to_field 'cho_dc_rights', extract_json('..license'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_dc_rights', extract_json('..access'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_dc_rights', extract_json('..access-rights'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_dc_rights', extract_json('..rights'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..annotation'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Annotation: ', 'تعليق توضيحي: ')
+to_field 'cho_description', extract_json('..architectural-detail'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
+to_field 'cho_description', extract_json('..architectural-detail-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
+to_field 'cho_description', extract_json('..architectural-detail-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Architectural detail: ', 'التفاصيل المعمارية: ')
+to_field 'cho_description', extract_json('..dimensions-of-original'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Dimensions of original: ', 'أبعاد الأصل: ')
+to_field 'cho_description', extract_json('..dimensions-of-printed-material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Dimensions of print: ', 'تقنية: ')
 to_field 'cho_description', extract_json('..description'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', extract_json('..note'), flatten_array, dlme_prepend('Note: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..description-arabic'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..description-english'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..inscription'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Inscription: ', 'النقش: ')
+to_field 'cho_description', extract_json('..notes'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Notes: ', 'ملحوظات: ')
+to_field 'cho_description', extract_json('..material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Material: ', 'مادة: ')
+to_field 'cho_description', extract_json('..photo-term'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Photo type: ', 'نوع الصورة: ')
+to_field 'cho_description', extract_json('..printed-material'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('..scale'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
+to_field 'cho_description', extract_json('..sheet-scale'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Scale: ', 'حصة تموينية: ')
+to_field 'cho_description', extract_json('..style-period'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Style period: ', 'فترة النمط: ')
+to_field 'cho_description', extract_json('..technique'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technique: ', 'أبعاد الطباعة: ')
+to_field 'cho_description', extract_json('..technical-details-of-original-drawing'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technical details: ', 'تفاصيل تقنية: ')
+to_field 'cho_description', extract_json('..technique-of-paper-drawing'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Technique: ', 'أبعاد الطباعة: ')
 to_field 'cho_edm_type', literal('Text'), lang('en')
 to_field 'cho_edm_type', literal('Text'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('..extent'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_extent', extract_json('..size'), flatten_array, transform(&:to_s), arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size: ', 'مقاس: ')
+to_field 'cho_extent', extract_json('..size-in-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..size-h--x--w-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..size-h-x-w-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..extent-in-cm'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Size in cm: ', 'الحجم بالسم: ')
+to_field 'cho_extent', extract_json('..measurements-h-x-w-in-cm-without-frame'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Measurements without frame (cm): ', 'القياسات بدون إطار (سم): ')
 to_field 'cho_format', extract_json('..format'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_format', extract_json('..physical-format'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_has_type', literal('Serials'), lang('en')
 to_field 'cho_has_type', literal('Serials'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('..call-number'), flatten_array
+to_field 'cho_identifier', extract_json('..contentdm-number'), flatten_array
+to_field 'cho_identifier', extract_json('..identifier'), flatten_array
+to_field 'cho_identifier', extract_json('..object-identifier'), flatten_array
+to_field 'cho_identifier', extract_json('..original-identifier'), flatten_array
 to_field 'cho_is_part_of', extract_json('..collection'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_is_part_of', extract_json('..collection-name'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_is_part_of', extract_json('..digital-collection'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_is_part_of', extract_json('..relation'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_language', extract_json('..language'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, lang('en')
 to_field 'cho_language', extract_json('..language'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_language', extract_json('..languages'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('..languages'), flatten_array, dlme_split(';'), dlme_split(':'), dlme_split(','), dlme_split('/'), dlme_split(' & '), dlme_split(' and '), dlme_split(' , and '), dlme_gsub('\\r', ''), dlme_gsub('\\n', ''), dlme_gsub('\r', ''), dlme_gsub('\n', ''), dlme_gsub('.', ''), dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_medium', extract_json('..medium'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_project_type', literal('issue'), lang('en')
+to_field 'cho_provenance', extract_json('..provenance'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('..source-donation-note'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_publisher', extract_json('..publisher'), flatten_array, lang('ar-Arab')
+to_field 'cho_related', extract_json('..united-nations-record'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..coverage-spatialnote'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_spatial', extract_json('..location'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_subject', extract_json('..subject'), flatten_array, dlme_split(';'), unique, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-country-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-country-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-english-name'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-getty-thesaurus-of-geographic-names-tgn'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-governorate-alternative'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-governorate-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-governorate-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-governorate-transliteration'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..location-governorate-arabic-alternative'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..site'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..site-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_spatial', extract_json('..site-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..keyword'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Keywords: ', 'الكلمات الرئيسية: ')
+to_field 'cho_subject', extract_json('..keywords'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en'), intelligent_prepend('Keywords: ', 'الكلمات الرئيسية: ')
+to_field 'cho_subject', extract_json('..subject'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-aat'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-lc'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-lcsh'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+# subject-lcsh-arabic is not present in harvested data, presumabely because subject-lchs-arabic is present and its a typo. Leaving
+# subject-lcsh-arabic for future proofing, becuaset they will eventually fix the error.
+to_field 'cho_subject', extract_json('..subject-lcsh-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-lchs-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..subject-tgm'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..topic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..topic-arabic'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_subject', extract_json('..topic-english'), flatten_array, dlme_split(';'), arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_type', extract_json('..genre'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_type', extract_json('..genre-aat'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_type', extract_json('..type'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_type', extract_json('..type-dcmi'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -122,6 +218,44 @@ to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## edition
+## egyptian-national?
+## gender
+## link-to-catalogue
+## relationship-to-auc
+## subseries-english
+## age
+## plate-number
+## profile
+## acknowledgements
+## published-in
+## description-of-plate
+## coordinated-longitude
+## titles-new
+## repository
+## project-type
+## series
+## nationality
+## source
+## link-to-catalog
+## name
+## state-edition
+## date-submitted
+## source-donation
+## acknowledgments
+## occupation
+## subseries-arabic
+## coordinates-latitude
+## substance
+## contentdm-file-name
+## patron
+## context
+## getty-aat
+## date-beginning
+## worktype
+## worktype-of-printed-material
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/mcgill.rb
+++ b/traject_configs/mcgill.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'dlme_json_resource_writer'
+require 'dlme_debug_writer'
+require 'macros/collection'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/each_record'
+require 'macros/language_extraction'
+require 'macros/normalize_language'
+require 'macros/normalize_type'
+require 'macros/path_to_file'
+require 'macros/prepend'
+require 'macros/string_helper'
+require 'macros/timestamp'
+require 'macros/transformation'
+require 'macros/title_extraction'
+require 'macros/version'
+require 'traject_plus'
+
+extend Macros::Collection
+extend Macros::DateParsing
+extend Macros::DLME
+extend Macros::EachRecord
+extend Macros::LanguageExtraction
+extend Macros::NormalizeLanguage
+extend Macros::NormalizeType
+extend Macros::PathToFile
+extend Macros::Prepend
+extend Macros::StringHelper
+extend Macros::Timestamp
+extend Macros::TitleExtraction
+extend Macros::Transformation
+extend Macros::Version
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::JSON
+
+settings do
+  provide 'allow_duplicate_values', false
+  provide 'allow_nil_values', false
+  provide 'allow_empty_fields', false
+  provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::JsonReader'
+end
+
+# Set Version & Timestamp on each record
+to_field 'transform_version', version
+to_field 'transform_timestamp', timestamp
+
+# File path
+to_field 'dlme_source_file', path_to_file
+
+to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('mcgill-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('mcgill-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('mcgill-')
+
+# Cho Required
+to_field 'id', extract_json('.id'),
+         flatten_array,
+         dlme_strip,
+         dlme_gsub('https://iiif.bodleian.ox.ac.uk/iiif/manifest/', ''),
+         dlme_gsub('.json', '')
+to_field 'cho_title', extract_json('.title'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'und-Latn'), default_multi_lang('Untitled', 'بدون عنوان')
+
+# Cho Other
+to_field 'cho_alternate', extract_json('.other-titles'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.annotator'), flatten_array, dlme_strip, dlme_prepend('Annotator: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.author-of-introduction'), flatten_array, dlme_strip, dlme_prepend('Author of introduction: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.compiler'), flatten_array, dlme_strip, dlme_prepend('Compiler: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.commentators'), flatten_array, dlme_strip, dlme_prepend('Commentators: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.contributor'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.editors'), flatten_array, dlme_strip, dlme_prepend('Editor: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.illustrator'), flatten_array, dlme_strip, dlme_prepend('Illustrator: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.printer'), flatten_array, dlme_strip, dlme_prepend('Printer: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.scribe'), flatten_array, dlme_strip, dlme_prepend('Scribe: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_contributor', extract_json('.translator'), flatten_array, dlme_strip, dlme_prepend('Translator: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_creator', extract_json('.author'), flatten_array, dlme_strip, dlme_prepend('Author: '), arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_creator', extract_json('.creator'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_date', extract_json('.date-statement'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_date_range_norm', extract_json('.date-statement'), flatten_array, dlme_strip, dlme_gsub('/', '-'), parse_range
+to_field 'cho_date_range_hijri', extract_json('.date-statement'), flatten_array, dlme_strip, dlme_gsub('/', '-'), parse_range, hijri_range
+to_field 'cho_dc_rights', literal('Photo: © Bodleian Libraries, University of Oxford, Terms of use: http://digital.bodleian.ox.ac.uk/terms.html'), lang('en')
+to_field 'cho_description', extract_json('.binding'), flatten_array, dlme_strip, dlme_prepend('Binding: '), lang('en')
+to_field 'cho_description', extract_json('.catalogue-description'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_description', extract_json('.collation'), flatten_array, dlme_strip, dlme_prepend('Collation: '), lang('en')
+to_field 'cho_description', extract_json('.contents'), flatten_array, dlme_strip, dlme_prepend('Contents: '), lang('en')
+to_field 'cho_description', extract_json('.contents-note'), flatten_array, dlme_strip, dlme_prepend('Contents note: '), lang('en')
+to_field 'cho_description', extract_json('.decoration'), flatten_array, dlme_strip, dlme_prepend('Decoration: '), lang('en')
+to_field 'cho_description', extract_json('.description'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'und-Latn')
+to_field 'cho_description', extract_json('.dimensions'), flatten_array, dlme_strip, dlme_prepend('Dimensions: '), lang('en')
+to_field 'cho_description', extract_json('.hand'), flatten_array, dlme_strip, dlme_prepend('Hand: '), lang('en')
+to_field 'cho_description', extract_json('.layout'), flatten_array, dlme_strip, dlme_prepend('Layout: '), lang('en')
+to_field 'cho_description', extract_json('.origin-note'), flatten_array, dlme_strip, dlme_prepend('Origin note: '), lang('en')
+to_field 'cho_description', extract_json('.record-origin'), flatten_array, dlme_strip, dlme_prepend('Record origin: '), lang('en')
+to_field 'cho_edm_type', literal('Text'), lang('en')
+to_field 'cho_edm_type', literal('Text'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_extent', extract_json('.extent'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_has_type', literal('Manuscripts'), lang('en')
+to_field 'cho_has_type', literal('Manuscripts'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_identifier', extract_json('.catalogue-identifier'), flatten_array, dlme_strip
+to_field 'cho_identifier', extract_json('.other-identifier'), flatten_array, dlme_strip
+to_field 'cho_identifier', extract_json('.shelfmark'), flatten_array, dlme_strip
+to_field 'cho_is_part_of', extract_json('.collection'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_language', extract_json('.language'), flatten_array, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.language'), flatten_array, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_medium', extract_json('.materials'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_publisher', extract_json('.publisher'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_provenance', extract_json('.former-owner'), flatten_array, dlme_strip, dlme_prepend('Former owner: '), lang('en')
+to_field 'cho_provenance', extract_json('.provenance'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_relation', extract_json('.related-items'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_spatial', extract_json('.place-of-origin'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_subject', extract_json('.subject'), flatten_array, dlme_strip, lang('en')
+
+# Agg
+to_field 'agg_data_provider', data_provider, lang('en')
+to_field 'agg_data_provider', data_provider_ar, lang('ar-Arab')
+to_field 'agg_data_provider_country', data_provider_country, lang('en')
+to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+to_field 'agg_is_shown_at' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_id' => [extract_json('.rendering'), flatten_array, dlme_strip],
+    'wr_is_referenced_by' => [extract_json('.id'), flatten_array, dlme_strip]
+  )
+end
+to_field 'agg_preview' do |_record, accumulator, context|
+  accumulator << transform_values(
+    context,
+    'wr_id' => [extract_json('.thumbnail'), flatten_array, at_index(0), dlme_strip],
+    'wr_is_referenced_by' => [extract_json('.id'), flatten_array, dlme_strip]
+  )
+end
+to_field 'agg_provider', provider, lang('en')
+to_field 'agg_provider', provider_ar, lang('ar-Arab')
+to_field 'agg_provider_country', provider_country, lang('en')
+to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+each_record convert_to_language_hash(
+  'agg_data_provider',
+  'agg_data_provider_country',
+  'agg_provider',
+  'agg_provider_country',
+  'cho_alternative',
+  'cho_contributor',
+  'cho_coverage',
+  'cho_creator',
+  'cho_date',
+  'cho_dc_rights',
+  'cho_description',
+  'cho_edm_type',
+  'cho_extent',
+  'cho_format',
+  'cho_has_part',
+  'cho_has_type',
+  'cho_is_part_of',
+  'cho_language',
+  'cho_medium',
+  'cho_provenance',
+  'cho_publisher',
+  'cho_relation',
+  'cho_source',
+  'cho_spatial',
+  'cho_subject',
+  'cho_temporal',
+  'cho_title',
+  'cho_type',
+  'dlme_collection',
+  'agg_data_provider_collection'
+)
+
+# NOTE: call add_cho_type_facet AFTER calling convert_to_language_hash fields
+each_record add_cho_type_facet

--- a/traject_configs/princeton.rb
+++ b/traject_configs/princeton.rb
@@ -56,56 +56,62 @@ to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_in
 
 # Cho Required
 to_field 'id', extract_json('.id'), flatten_array, dlme_split('/'), at_index(-2), dlme_strip
-to_field 'cho_title', extract_json('.title[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_title', extract_json('.uniform-title[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_title', extract_json('.title'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_title', extract_json('.uniform-title'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
 
 # Cho Other
-to_field 'cho_alternative', extract_json('.alternative[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_creator', extract_json('.author[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_creator', extract_json('.creator[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.artist[0]'), flatten_array, dlme_strip, dlme_prepend('Artist: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.abridger[0]'), flatten_array, dlme_strip, dlme_prepend('Abridger: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.annotator[0]'), flatten_array, dlme_strip, dlme_prepend('Annotator: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.calligrapher[0]'), flatten_array, dlme_strip, dlme_prepend('Calligrapher: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.compiler[0]'), flatten_array, dlme_strip, dlme_prepend('Compiler: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_alternative', extract_json('.alternative'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_creator', extract_json('.author'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_creator', extract_json('.creator'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.artist'), flatten_array, dlme_strip, dlme_prepend('Artist: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.abridger'), flatten_array, dlme_strip, dlme_prepend('Abridger: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.annotator'), flatten_array, dlme_strip, dlme_prepend('Annotator: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.calligrapher'), flatten_array, dlme_strip, dlme_prepend('Calligrapher: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.compiler'), flatten_array, dlme_strip, dlme_prepend('Compiler: '), arabic_script_lang_or_default('und-Arab', 'en')
 to_field 'cho_contributor', extract_json('..contributor'), flatten_array, flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.director[0]'), flatten_array, dlme_strip, dlme_prepend('Director: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_contributor', extract_json('.rendered-actors[0]'), flatten_array, dlme_strip, dlme_prepend('Actor: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.scribe[0]'), flatten_array, dlme_strip, dlme_prepend('Scribe: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_contributor', extract_json('.translator[0]'), flatten_array, dlme_strip, dlme_prepend('Translator: '), arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_date', extract_json('.date[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_norm', extract_json('.date[0]'), flatten_array, dlme_strip, parse_range
-to_field 'cho_date_range_hijri', extract_json('.date[0]'), flatten_array, dlme_strip, parse_range, hijri_range
-to_field 'cho_date', extract_json('.date-created[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_norm', extract_json('.date-created[0]'), flatten_array, dlme_strip, parse_range
-to_field 'cho_date_range_hijri', extract_json('.date-created[0]'), flatten_array, dlme_strip, parse_range, hijri_range
+to_field 'cho_contributor', extract_json('.director'), flatten_array, dlme_strip, dlme_prepend('Director: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_contributor', extract_json('.rendered-actors'), flatten_array, dlme_strip, dlme_prepend('Actor: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.scribe'), flatten_array, dlme_strip, dlme_prepend('Scribe: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_contributor', extract_json('.translator'), flatten_array, dlme_strip, dlme_prepend('Translator: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_date', extract_json('.date'), flatten_array, dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_norm', extract_json('.date'), flatten_array, dlme_strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date'), flatten_array, dlme_strip, parse_range, hijri_range
+to_field 'cho_date', extract_json('.date-created'), flatten_array, dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_norm', extract_json('.date-created'), flatten_array, dlme_strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date-created'), flatten_array, dlme_strip, parse_range, hijri_range
 to_field 'cho_dc_rights', literal('https://rbsc.princeton.edu/services/imaging-publication-services'), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', extract_json('.abstract[0]'), flatten_array, dlme_strip, dlme_prepend('Abstract: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', extract_json('.binding-note[0]'), flatten_array, dlme_strip, dlme_prepend('Binding note: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', extract_json('.contents[0]'), flatten_array, dlme_strip, dlme_prepend('Contents: '), arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_description', extract_json('.description[0]'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_description', extract_json('.abstract'), flatten_array, dlme_strip, dlme_prepend('Abstract: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('.binding-note'), flatten_array, dlme_strip, dlme_prepend('Binding note: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('.contents'), flatten_array, dlme_strip, dlme_prepend('Contents: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_description', extract_json('.description'), flatten_array, dlme_strip, lang('en')
 to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('princeton-'), translation_map('has_type_from_collection'), translation_map('edm_type_from_has_type'), lang('en')
 to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('princeton-'), translation_map('has_type_from_collection'), translation_map('edm_type_from_has_type'), translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_extent', extract_json('.extent[0]'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_extent', extract_json('.extent'), flatten_array, dlme_strip, lang('en')
 to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('princeton-'), translation_map('has_type_from_collection'), lang('en')
 to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(2), dlme_gsub('_', '-'), dlme_prepend('princeton-'), translation_map('has_type_from_collection'), translation_map('has_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_identifier', extract_json('.call-number[0]'), flatten_array, dlme_strip
-to_field 'cho_identifier', extract_json('.identifier[0]'), flatten_array, dlme_strip
-to_field 'cho_identifier', extract_json('.local-identifier[0]'), flatten_array, dlme_strip
-to_field 'cho_identifier', extract_json('.replaces[0]'), flatten_array, dlme_strip, dlme_prepend('Replaces: ')
-to_field 'cho_is_part_of', extract_json('.member-of-collections[0]'), flatten_array, dlme_strip, lang('en')
+to_field 'cho_identifier', extract_json('.call-number'), flatten_array, dlme_strip
+to_field 'cho_identifier', extract_json('.identifier'), flatten_array, dlme_strip
+to_field 'cho_identifier', extract_json('.local-identifier'), flatten_array, dlme_strip
+to_field 'cho_identifier', extract_json('.replaces'), flatten_array, dlme_strip, dlme_prepend('Replaces: ')
+to_field 'cho_is_part_of', extract_json('.member-of-collections'), flatten_array, dlme_strip, lang('en')
 # Leaving out the 'text-language' column because its mostly redundant.
-to_field 'cho_language', extract_json('.language[0]'), flatten_array, dlme_strip, normalize_language, lang('en')
-to_field 'cho_language', extract_json('.language[0]'), flatten_array, dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
-to_field 'cho_provenance', extract_json('.collector[0]'), flatten_array, dlme_prepend('Collector: [0]'), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_provenance', extract_json('.former-owner[0]'), flatten_array, dlme_prepend('Former owner: [0]'), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_provenance', extract_json('.provenance[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_publisher', extract_json('.publisher[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_spatial', extract_json('.geographic-origin[0]'), dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_subject', extract_json('.genre[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_subject', extract_json('.subject[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_type', extract_json('.resource-type[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_type', extract_json('.type[0]'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_language', extract_json('.text-language'), flatten_array, dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.text-language'), flatten_array, dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
+to_field 'cho_provenance', extract_json('.collector'), flatten_array, dlme_prepend('Collector: '), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('.donor'), flatten_array, dlme_strip, dlme_prepend('Donor: '), arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('.former-owner'), flatten_array, dlme_prepend('Former owner: '), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('.provenance'), flatten_array, dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('.owner'), flatten_array, dlme_prepend('Owner: '), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_provenance', extract_json('.patron'), flatten_array, dlme_prepend('Patron: '), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_publisher', extract_json('.publisher'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_spatial', extract_json('.geographic-origin'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_spatial', extract_json('.location'), flatten_array, dlme_strip, dlme_prepend('Location: '), arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_subject', extract_json('.genre'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_subject', extract_json('.subject'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_type', extract_json('.resource-type'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_type', extract_json('.type'), flatten_array, dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
 
 # Agg
 to_field 'agg_data_provider', data_provider, lang('en')
@@ -122,13 +128,30 @@ end
 # This should be removed once Princeton fixes the data issue.
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
-                                  'wr_id' => [extract_json('.thumbnail[0]'), flatten_array, first_only, dlme_split('/full/'), dlme_strip, dlme_append('/full/!400,400/0/dlme_default.jpg'), dlme_default('https://iiif-cloud.princeton.edu/iiif/2/ce%2Fa3%2F3e%2Fcea33ed8c16141de94a3414f38290306%2Fintermediate_file/full/!400,400/0/dlme_default.jpg')],
+                                  'wr_id' => [extract_json('.thumbnail'), flatten_array, first_only, dlme_split('/full/'), dlme_strip, dlme_append('/full/!400,400/0/dlme_default.jpg'), dlme_default('https://iiif-cloud.princeton.edu/iiif/2/ce%2Fa3%2F3e%2Fcea33ed8c16141de94a3414f38290306%2Fintermediate_file/full/!400,400/0/dlme_default.jpg')],
                                   'wr_is_referenced_by' => [extract_json('.id'), flatten_array])
 end
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## electronic-locations
+## claimed-by
+## conservator
+## source-acquisition
+## indexed-by
+## auctioneer
+## edition
+## content-type
+## attributed-name
+## binder
+## dedicatee
+## embargo-date
+## portion-note
+## rendered-holding-location
+## inscriber
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/sakip_sabanci_museum.rb
+++ b/traject_configs/sakip_sabanci_museum.rb
@@ -55,42 +55,52 @@ to_field 'id', extract_json('.id'), dlme_gsub('https://cdm21044.contentdm.oclc.o
 to_field 'cho_title', extract_json('.başlık-title'), flatten_array, lang('tr-Latn')
 
 # Cho Other
+to_field 'cho_alternative', extract_json('.başlık-alternatif-title-alternative'), flatten_array, lang('tr-Latn')
 to_field 'cho_alternative', extract_json('.diğer-başlık-title-alternative'), flatten_array, lang('tr-Latn')
+
+to_field 'cho_creator', extract_json('.müellif-authorcreator'), flatten_array, dlme_prepend('Artist: '), lang('tr-Latn')
 to_field 'cho_creator', extract_json('.sanatçı-artist'), flatten_array, dlme_prepend('Artist: '), lang('tr-Latn')
-to_field 'cho_creator', extract_json('.sorumluluk-alanı-creator'), flatten_array, dlme_prepend('Artist: '), lang('tr-Latn')
+to_field 'cho_creator', extract_json('.yazar-creator'), flatten_array, dlme_prepend('Artist: '), lang('tr-Latn')
 to_field 'cho_contributor', extract_json('.hattat-calligrapher'), flatten_array, dlme_prepend('Calligrapher: '), lang('tr-Latn')
 to_field 'cho_contributor', extract_json('.müzehhip-illuminator'), flatten_array, dlme_prepend('Illuminator: '), lang('tr-Latn')
 to_field 'cho_contributor', extract_json('.tuğrakeş-contributors'), flatten_array, lang('tr-Latn')
 to_field 'cho_contributor', extract_json('.usta-contributors'), flatten_array, lang('tr-Latn')
+to_field 'cho_date', extract_json('.kopya-tarihi-date'), flatten_array, lang('tr-Latn')
 to_field 'cho_date', extract_json('.tarih-date'), flatten_array, lang('tr-Latn')
 to_field 'cho_date_range_norm', extract_json('.tarih-date'), flatten_array, parse_range
 to_field 'cho_date_range_hijri', extract_json('.tarih-date'), flatten_array, parse_range, hijri_range
 to_field 'cho_dc_rights', extract_json('.telif-hakkı-copyright'), flatten_array, lang('tr-Latn')
-to_field 'cho_dc_rights', extract_json('.telif-hakkı-rights'), flatten_array, lang('tr-Latn')
 to_field 'cho_description', extract_json('.açıklama-description'), flatten_array, lang('tr-Latn')
 to_field 'cho_description', extract_json('.fiziksel-görünüm-physical-appearance'), flatten_array, dlme_prepend('Physical Appearance: '), lang('tr-Latn')
-to_field 'cho_description', extract_json('.kayıtlar-inscriptions/marks'), flatten_array, dlme_prepend('Inscriptions: '), lang('tr-Latn')
+to_field 'cho_description', extract_json('.kayıtlar-inscriptionsmarks'), flatten_array, dlme_prepend('Inscriptions: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.ketebe-ve-zehebe-kaydı-inscriptions'), flatten_array, dlme_prepend('Inscriptions: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.konservasyon-conservation'), flatten_array, dlme_prepend('Conservation: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.cilt-binding'), flatten_array, dlme_prepend('Binding: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.malzemeler-materials'), flatten_array, dlme_prepend('Materials: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.mühürler-ve-diğer-kayıtlar-inscriptions'), flatten_array, dlme_prepend('Inscriptions: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.tezhipler-illuminations'), flatten_array, dlme_prepend('Illuminations: '), lang('tr-Latn')
-to_field 'cho_description', extract_json('.teknik-materials/techniques'), flatten_array, dlme_prepend('Materials/Techniques: '), lang('tr-Latn')
+to_field 'cho_description', extract_json('.tasvirler-ve-şekiller-illustrations'), flatten_array, dlme_prepend('Illustrations: '), lang('tr-Latn')
+to_field 'cho_description', extract_json('.malzemeteknik-materialstechniques'), flatten_array, dlme_prepend('Materials/Techniques: '), lang('tr-Latn')
+to_field 'cho_description', extract_json('.teknik-materialstechniques'), flatten_array, dlme_prepend('Materials/Techniques: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.transkripsiyon-transcription'), flatten_array, dlme_prepend('Transcription: '), lang('tr-Latn')
 to_field 'cho_description', extract_json('.yazı-cinsi-script'), flatten_array, dlme_prepend('Script: '), lang('tr-Latn')
 to_field 'cho_edm_type', extract_json('.tür-type'), flatten_array, normalize_has_type, normalize_edm_type, lang('en')
 to_field 'cho_edm_type', extract_json('.tür-type'), flatten_array, normalize_has_type, normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_extent', extract_json('.boyutlar-measurements'), flatten_array, dlme_prepend('Measurements: '), lang('en')
-to_field 'cho_format', extract_json('.format'), flatten_array, dlme_strip, lang('tr-Latn')
 to_field 'cho_has_type', extract_json('.tür-type'), flatten_array, normalize_has_type, lang('en')
 to_field 'cho_has_type', extract_json('.tür-type'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.envanter-numarası-accession-number'), flatten_array, dlme_strip
 to_field 'cho_identifier', extract_json('.envanter-numarası-identifier'), flatten_array, dlme_strip
-to_field 'cho_language', extract_json('.dil-language'), flatten_array, dlme_split(';'), dlme_strip, normalize_language, lang('en')
-to_field 'cho_publisher', extract_json('.yayıncı-publisher'), flatten_array, lang('en')
+to_field 'cho_language', extract_json('.dil-language'), flatten_array, dlme_split(';'), dlme_split('/'), dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.dil-language'), flatten_array, dlme_split(';'), dlme_split('/'), dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('en')
+to_field 'cho_provenance', extract_json('.müzeye-geliş-şekli-provenance'), flatten_array, lang('en')
+to_field 'cho_provenance', extract_json('.müzeye-geliş-tarihi-provenance-date'), flatten_array, dlme_prepend('Provenance date: '), lang('en')
+to_field 'cho_provenance', extract_json('.ssm-provenance'), flatten_array, lang('en')
+to_field 'cho_publisher', extract_json('.yayın-publication'), flatten_array, lang('en')
+to_field 'cho_spatial', extract_json('.yer-creation-place'), flatten_array, lang('en')
+to_field 'cho_subject', extract_json('.konu-subject'), flatten_array, lang('en')
 to_field 'cho_relation', extract_json('.ayrıca-bakınız-see-also'), flatten_array, lang('en')
-to_field 'cho_temporal', extract_json('.dönem-object/work-culture'), flatten_array, lang('tr-Latn')
+to_field 'cho_temporal', extract_json('.dönem-objectwork-culture'), flatten_array, lang('tr-Latn')
 to_field 'cho_type', extract_json('.tür-type'), flatten_array, lang('tr-Latn')
 
 # Agg
@@ -122,6 +132,17 @@ to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
 to_field 'agg_data_provider_country', data_provider_country, lang('en')
 to_field 'agg_data_provider_country', data_provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## atıf-notu-cited
+## belge-document
+## bulunduğu-yer-current-repository
+## context
+## durum-status
+## mücellid-binder
+## profile
+## repository
+## source
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/template.rb
+++ b/traject_configs/template.rb
@@ -1,43 +1,51 @@
 # frozen_string_literal: true
 
-require 'traject_plus'
-require 'macros/csv'
 require 'dlme_json_resource_writer'
 require 'dlme_debug_writer'
+require 'macros/collection'
+require 'macros/csv'
 require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/each_record'
+require 'macros/field_extraction'
 require 'macros/language_extraction'
 require 'macros/normalize_language'
 require 'macros/normalize_type'
 require 'macros/path_to_file'
+require 'macros/prepend'
+require 'macros/transformation'
+require 'macros/string_helper'
 require 'macros/timestamp'
+require 'macros/title_extraction'
 require 'macros/version'
+require 'traject_plus'
 
+extend Macros::Collection
 extend Macros::Csv
-extend Macros::DateParsing
 extend Macros::DLME
+extend Macros::DateParsing
 extend Macros::EachRecord
+extend Macros::FieldExtraction
 extend Macros::LanguageExtraction
 extend Macros::NormalizeLanguage
 extend Macros::NormalizeType
 extend Macros::PathToFile
+extend Macros::Prepend
+extend Macros::StringHelper
+extend Macros::Transformation
 extend Macros::Timestamp
+extend Macros::TitleExtraction
 extend Macros::Version
 extend TrajectPlus::Macros
-extend TrajectPlus::Macros::Csv
+extend TrajectPlus::Macros::JSON
 
 settings do
   provide 'allow_duplicate_values', false
   provide 'allow_nil_values', false
   provide 'allow_empty_fields', false
-  provide 'reader_class_name', 'TrajectPlus::CsvReader'
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
+  provide 'reader_class_name', 'TrajectPlus::JsonReader'
 end
-
-# File path
-to_field 'dlme_source_file', path_to_file
-
 # Set Version & Timestamp on each record
 to_field 'transform_version', version
 to_field 'transform_timestamp', timestamp
@@ -45,6 +53,8 @@ to_field 'transform_timestamp', timestamp
 to_field 'agg_data_provider_collection_id' # Arabic value
 to_field 'agg_data_provider_collection' # English value
 to_field 'agg_data_provider_collection'
+
+to_field 'dlme_source_file', path_to_file
 
 # Cho Required
 to_field 'id'
@@ -115,6 +125,9 @@ to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## none
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/ucla_armenian.rb
+++ b/traject_configs/ucla_armenian.rb
@@ -15,6 +15,7 @@ require 'macros/prepend'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
+require 'macros/transformation'
 require 'macros/version'
 require 'traject_plus'
 
@@ -31,6 +32,7 @@ extend Macros::Prepend
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
+extend Macros::Transformation
 extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
@@ -50,57 +52,64 @@ to_field 'transform_timestamp', timestamp
 # File path
 to_field 'dlme_source_file', path_to_file
 
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-'), translation_map('agg_collection_from_provider_id'), lang('en')
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-')
 
 # CHO Required
-to_field 'id', extract_json('.id'), gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), gsub('\/!200,200\/0\/default.jpg', '')
-to_field 'cho_title', extract_json('..title'), flatten_array, strip, armenian_script_lang_or_default('hy-Armn', 'en')
+to_field 'id', extract_json('.id'), dlme_gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), dlme_gsub('\/!200,200\/0\/default.jpg', '')
+to_field 'cho_title', extract_json('..title'), flatten_array, dlme_strip, armenian_script_lang_or_default('hy-Armn', 'en')
 
 # CHO Other
 to_field 'cho_alternative', extract_json('..alternative'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
 to_field 'cho_creator', extract_json('..creator'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
 to_field 'cho_contributor', extract_json('..contributor'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
-to_field 'cho_date', extract_json('.date[0]'), strip, armenian_script_lang_or_default('hy-Armn', 'en')
-to_field 'cho_date_range_norm', extract_json('.date[0]'), strip, parse_range
-to_field 'cho_date_range_hijri', extract_json('.date[0]'), strip, parse_range, hijri_range
+to_field 'cho_date', extract_json('.date[0]'), dlme_strip, armenian_script_lang_or_default('hy-Armn', 'en')
+to_field 'cho_date_range_norm', extract_json('.date[0]'), dlme_strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date[0]'), dlme_strip, parse_range, hijri_range
+to_field 'cho_dc_rights', extract_json('.rights'), flatten_array, lang('en')
 to_field 'cho_description', extract_json('..description'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, lang('en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, lang('en')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, lang('en')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, lang('en')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_format', extract_json('..format'), flatten_array, lang('en')
 to_field 'cho_identifier', extract_json('..identifier'), flatten_array
 to_field 'cho_is_part_of', extract_json('..source'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
 to_field 'cho_publisher', extract_json('..publisher'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
 to_field 'cho_subject', extract_json('..subject'), flatten_array, armenian_script_lang_or_default('hy-Armn', 'en')
-# UCLA requested to translated LoC urls to user-facing type values
-to_field 'cho_type', extract_json('..type'), flatten_array, strip, translation_map('type_from_loc'), lang('en')
+# UCLA requested to translate LoC urls to user-facing type values
+to_field 'cho_type', extract_json('..type'), flatten_array, dlme_strip, translation_map('type_from_loc'), lang('en')
+to_field 'cho_type', extract_json('..hasType'), flatten_array, dlme_strip, translation_map('type_from_loc'), lang('en')
 
 # Agg
-to_field 'agg_data_provider', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), lang('en')
-to_field 'agg_data_provider', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), lang('en')
-to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), translation_map('country_en_to_ar'), lang('ar-Arab')
+to_field 'agg_data_provider', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), lang('en')
+to_field 'agg_data_provider', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), lang('en')
+to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), translation_map('country_en_to_ar'), lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.isShownAt[0]')],
-    'wr_is_referenced_by' => [extract_json('identifier[-1]'), gsub('oai:library.ucla.edu:', ''), gsub(':', '%3A'), gsub('/', '%2F'), prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
+    'wr_is_referenced_by' => [extract_json('identifier[-1]'), dlme_gsub('oai:library.ucla.edu:', ''), dlme_gsub(':', '%3A'), dlme_gsub('/', '%2F'), dlme_prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.object[0]')],
-    'wr_is_referenced_by' => [extract_json('identifier[-1]'), gsub('oai:library.ucla.edu:', ''), gsub(':', '%3A'), gsub('/', '%2F'), prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
+    'wr_is_referenced_by' => [extract_json('identifier[-1]'), dlme_gsub('oai:library.ucla.edu:', ''), dlme_gsub(':', '%3A'), dlme_gsub('/', '%2F'), dlme_prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
   )
 end
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## none
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/ucla_iiif.rb
+++ b/traject_configs/ucla_iiif.rb
@@ -15,6 +15,7 @@ require 'macros/prepend'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
+require 'macros/transformation'
 require 'macros/version'
 require 'traject_plus'
 
@@ -31,6 +32,7 @@ extend Macros::Prepend
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
+extend Macros::Transformation
 extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
@@ -50,57 +52,64 @@ to_field 'transform_timestamp', timestamp
 # File path
 to_field 'dlme_source_file', path_to_file
 
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-'), translation_map('agg_collection_from_provider_id'), lang('en')
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-')
 
 # CHO Required
-to_field 'id', extract_json('.id'), gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), gsub('\/!200,200\/0\/default.jpg', '')
+to_field 'id', extract_json('.id'), dlme_gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), dlme_gsub('\/!200,200\/0\/default.jpg', '')
 to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 
 # CHO Other
 to_field 'cho_alternative', extract_json('..alternative'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 to_field 'cho_creator', extract_json('..creator'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 to_field 'cho_contributor', extract_json('..contributor'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_date', extract_json('.date[0]'), strip, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_date_range_norm', extract_json('.date[0]'), strip, parse_range
-to_field 'cho_date_range_hijri', extract_json('.date[0]'), strip, parse_range, hijri_range
+to_field 'cho_date', extract_json('.date[0]'), dlme_strip, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_date_range_norm', extract_json('.date[0]'), dlme_strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date[0]'), dlme_strip, parse_range, hijri_range
+to_field 'cho_dc_rights', extract_json('.rights'), flatten_array, lang('en')
 to_field 'cho_description', extract_json('..description'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, lang('en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, lang('en')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, lang('en')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, lang('en')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_format', extract_json('..format'), flatten_array, lang('en')
 to_field 'cho_identifier', extract_json('..identifier'), flatten_array
 to_field 'cho_is_part_of', extract_json('..source'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
 to_field 'cho_publisher', extract_json('..publisher'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 # UCLA requested to translated LoC urls to user-facing type values
 to_field 'cho_type', extract_json('..type'), flatten_array, translation_map('type_from_loc'), lang('en')
+to_field 'cho_type', extract_json('..hasType'), flatten_array, dlme_strip, translation_map('type_from_loc'), lang('en')
 
 # Agg
-to_field 'agg_data_provider', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), lang('en')
-to_field 'agg_data_provider', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), lang('en')
-to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), translation_map('country_en_to_ar'), lang('ar-Arab')
+to_field 'agg_data_provider', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), lang('en')
+to_field 'agg_data_provider', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), lang('en')
+to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), translation_map('country_en_to_ar'), lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.isShownAt[0]')],
-    'wr_is_referenced_by' => [extract_json('.identifier[-1]'), gsub('oai:library.ucla.edu:', ''), gsub(':', '%3A'), gsub('/', '%2F'), prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
+    'wr_is_referenced_by' => [extract_json('.identifier[-1]'), dlme_gsub('oai:library.ucla.edu:', ''), dlme_gsub(':', '%3A'), dlme_gsub('/', '%2F'), dlme_prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
   )
 end
 to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.object[0]')],
-    'wr_is_referenced_by' => [extract_json('.identifier[-1]'), gsub('oai:library.ucla.edu:', ''), gsub(':', '%3A'), gsub('/', '%2F'), prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
+    'wr_is_referenced_by' => [extract_json('.identifier[-1]'), dlme_gsub('oai:library.ucla.edu:', ''), dlme_gsub(':', '%3A'), dlme_gsub('/', '%2F'), dlme_prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
   )
 end
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## none
 
 each_record convert_to_language_hash(
   'agg_data_provider',

--- a/traject_configs/ucla_no_preview.rb
+++ b/traject_configs/ucla_no_preview.rb
@@ -15,6 +15,7 @@ require 'macros/prepend'
 require 'macros/string_helper'
 require 'macros/timestamp'
 require 'macros/title_extraction'
+require 'macros/transformation'
 require 'macros/version'
 require 'traject_plus'
 
@@ -31,6 +32,7 @@ extend Macros::Prepend
 extend Macros::StringHelper
 extend Macros::Timestamp
 extend Macros::TitleExtraction
+extend Macros::Transformation
 extend Macros::Version
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
@@ -50,50 +52,57 @@ to_field 'transform_timestamp', timestamp
 # File path
 to_field 'dlme_source_file', path_to_file
 
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-'), translation_map('agg_collection_from_provider_id'), lang('en')
-to_field 'agg_data_provider_collection', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_collection_id', path_to_file, split('/'), at_index(-2), gsub('_', '-'), prepend('ucla-')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('agg_collection_from_provider_id'), lang('en')
+to_field 'agg_data_provider_collection', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('agg_collection_from_provider_id'), translation_map('agg_collection_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_collection_id', path_to_file, dlme_split('/'), at_index(-2), dlme_gsub('_', '-'), dlme_prepend('ucla-')
 
 # CHO Required
-to_field 'id', extract_json('.id'), gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), gsub('\/!200,200\/0\/default.jpg', '')
+to_field 'id', extract_json('.id'), dlme_gsub('https:\/\/iiif.library.ucla.edu\/iiif\/2\/', ''), dlme_gsub('\/!200,200\/0\/default.jpg', '')
 to_field 'cho_title', extract_json('..title'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 
 # CHO Other
 to_field 'cho_alternative', extract_json('..alternative'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 to_field 'cho_creator', extract_json('..creator'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
 to_field 'cho_contributor', extract_json('..contributor'), flatten_array, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date', extract_json('.date[0]'), strip, arabic_script_lang_or_default('ar-Arab', 'en')
-to_field 'cho_date_range_norm', extract_json('.date[0]'), strip, parse_range
-to_field 'cho_date_range_hijri', extract_json('.date[0]'), strip, parse_range, hijri_range
+to_field 'cho_date', extract_json('.date[0]'), dlme_strip, arabic_script_lang_or_default('ar-Arab', 'en')
+to_field 'cho_date_range_norm', extract_json('.date[0]'), dlme_strip, parse_range
+to_field 'cho_date_range_hijri', extract_json('.date[0]'), dlme_strip, parse_range, hijri_range
+to_field 'cho_dc_rights', extract_json('.rights'), flatten_array, lang('en')
 to_field 'cho_description', extract_json('..description'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, lang('en')
-to_field 'cho_edm_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, lang('en')
-to_field 'cho_has_type', path_to_file, split('/'), at_index(3), gsub('_', '-'), prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, lang('en')
+to_field 'cho_edm_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_edm_type, translation_map('edm_type_ar_from_en'), lang('ar-Arab')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, lang('en')
+to_field 'cho_has_type', path_to_file, dlme_split('/'), at_index(3), dlme_gsub('_', '-'), dlme_prepend('ucla-'), translation_map('has_type_from_collection'), normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_format', extract_json('..format'), flatten_array, lang('en')
 to_field 'cho_identifier', extract_json('..identifier'), flatten_array
 to_field 'cho_is_part_of', extract_json('..source'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, lang('en')
+to_field 'cho_language', extract_json('.language'), flatten_array, dlme_strip, normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
 to_field 'cho_publisher', extract_json('..publisher'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
 to_field 'cho_subject', extract_json('..subject'), flatten_array, arabic_script_lang_or_default('und-Arab', 'en')
-# UCLA requested to translated LoC urls to user-facing type values
+# UCLA requested to translate LoC urls to user-facing type values
 to_field 'cho_type', extract_json('..type'), flatten_array, translation_map('type_from_loc'), lang('en')
+to_field 'cho_type', extract_json('..hasType'), flatten_array, dlme_strip, translation_map('type_from_loc'), lang('en')
 
 # Agg
-to_field 'agg_data_provider', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), lang('en')
-to_field 'agg_data_provider', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_ar_from_en'), lang('ar-Arab')
-to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), lang('en')
-to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), translation_map('country_en_to_ar'), lang('ar-Arab')
+to_field 'agg_data_provider', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), lang('en')
+to_field 'agg_data_provider', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_ar_from_en'), lang('ar-Arab')
+to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), lang('en')
+to_field 'agg_data_provider_country', extract_json('.dataProvider[0]'), dlme_default('University of California, Los Angeles. Library. Department of Special Collections'), translation_map('data_provider_to_country'), translation_map('country_en_to_ar'), lang('ar-Arab')
 to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(
     context,
     'wr_id' => [extract_json('.isShownAt[0]')],
-    'wr_is_referenced_by' => [extract_json('identifier[-1]'), gsub('oai:library.ucla.edu:', ''), gsub(':', '%3A'), gsub('/', '%2F'), prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
+    'wr_is_referenced_by' => [extract_json('identifier[-1]'), dlme_gsub('oai:library.ucla.edu:', ''), dlme_gsub(':', '%3A'), dlme_gsub('/', '%2F'), dlme_prepend('https://iiif.library.ucla.edu/'), append('/manifest')]
   )
 end
 to_field 'agg_provider', provider, lang('en')
 to_field 'agg_provider', provider_ar, lang('ar-Arab')
 to_field 'agg_provider_country', provider_country, lang('en')
 to_field 'agg_provider_country', provider_country_ar, lang('ar-Arab')
+
+# Ignored Fields
+## none
 
 each_record convert_to_language_hash(
   'agg_data_provider',


### PR DESCRIPTION
…ng all harvested fields

## Why was this change made?

I added a `bin/validate-traject` helper in dlme-airflow a while back that helps me check mapped fields against harvested fields to ensure we are mapping everything. I just used it to refresh all of these configs.

## How was this change tested?

local transform

## Which documentation and/or configurations were updated?

n/a

