### PR TITLE
adjusts Penn museum, adds new title extraction macro, removes unused …

### DIFF
--- a/spec/lib/traject/macros/title_extraction_spec.rb
+++ b/spec/lib/traject/macros/title_extraction_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Macros::TitleExtraction do
     end
   end
 
-  describe 'json_title_or' do
+  describe 'title_or' do
     # Sample records
     let(:both_fields) { { 'title' => 'Some title', 'other' => 'Some other field' } }
     let(:only_other) { { 'other' => 'Some other field' } }
 
     before do
       indexer.instance_eval do
-        to_field 'cho_title', json_title_or('title', 'other')
+        to_field 'cho_title', title_or('title', 'other')
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe Macros::TitleExtraction do
     end
   end
 
-  describe 'json_title_plus' do
+  describe 'title_plus' do
     # Sample records
     let(:both_fields) { { 'title' => 'Some title', 'other' => 'Some other field' } }
     let(:only_other) { { 'other' => 'Some other field' } }
@@ -42,7 +42,7 @@ RSpec.describe Macros::TitleExtraction do
 
     before do
       indexer.instance_eval do
-        to_field 'cho_title', json_title_plus('title', 'other')
+        to_field 'cho_title', title_plus('title', 'other')
       end
     end
 
@@ -59,53 +59,28 @@ RSpec.describe Macros::TitleExtraction do
     end
   end
 
-  describe '#xpath_title_or_desc' do
-    let(:title_only_record) do
-      <<-XML
-        <record>
-          <metadata>
-            <title>Qur'an</title>
-          </metadata>
-        </record>
-      XML
-    end
-    let(:title_only) { Nokogiri::XML.parse(title_only_record) }
-    let(:desc_only_record) do
-      <<-XML
-        <record>
-          <metadata>
-            <description>Arabic Manuscript</descritpion>
-          </metadata>
-        </record>
-      XML
-    end
-    let(:desc_only) { Nokogiri::XML.parse(desc_only_record) }
-    let(:neither_record) do
-      <<-XML
-        <record>
-          <metadata>
-          </metadata>
-        </record>
-      XML
-    end
-    let(:neither) { Nokogiri::XML.parse(neither_record) }
+  describe 'title_plus_default' do
+    # Sample records
+    let(:both_fields) { { 'title' => 'Some title', 'other' => 'Some other field' } }
+    let(:only_other) { { 'other' => 'Some other field' } }
+    let(:only_title) { { 'title' => 'Some title' } }
 
     before do
       indexer.instance_eval do
-        to_field 'cho_title', xpath_title_or_desc('/record/metadata/title', '/record/metadata/description')
+        to_field 'cho_title', title_plus_default('title', 'other', 'Untitled')
       end
     end
 
-    it 'has title provided a value' do
-      expect(indexer.map_record(title_only)).to eq('cho_title' => ["Qur'an"])
+    it 'has title and other field present' do
+      expect(indexer.map_record(both_fields)).to eq('cho_title' => ['Some title Some other field'])
     end
 
-    it 'has description but no title' do
-      expect(indexer.map_record(desc_only)).to eq('cho_title' => ['Arabic Manuscript'])
+    it 'has other only' do
+      expect(indexer.map_record(only_other)).to eq('cho_title' => ['Untitled Some other field'])
     end
 
-    it 'has neither title nor description' do
-      expect(indexer.map_record(neither)).to eq({})
+    it 'has title only' do
+      expect(indexer.map_record(only_title)).to eq('cho_title' => ['Some title'])
     end
   end
 end

--- a/traject_configs/harvard_stuart_cary_welch.rb
+++ b/traject_configs/harvard_stuart_cary_welch.rb
@@ -55,7 +55,7 @@ to_field 'dlme_source_file', path_to_file
 to_field 'id', generate_mods_id
 # Both titles need the same langauge value
 to_field 'cho_title', extract_mods('/*/mods:titleInfo[1]/mods:title'), prepend('Main Title: '), lang('und-Latn')
-to_field 'cho_title', xpath_title_plus('/*/mods:relatedItem[@type="constituent"]/mods:titleInfo/mods:title', '/*/mods:relatedItem/mods:recordInfo/mods:recordIdentifier'), prepend('Image Title: '), lang('und-Latn')
+to_field 'cho_title', extract_mods('/*/mods:relatedItem[@type="constituent"]/mods:titleInfo/mods:title'), prepend('Image Title: '), lang('und-Latn') # called xpath_title_plus
 
 # CHO Other
 to_field 'cho_alternative', extract_mods('/*/mods:titleInfo[@type="alternative"]/mods:title'), lang('en')

--- a/traject_configs/lausanne_ias.rb
+++ b/traject_configs/lausanne_ias.rb
@@ -54,7 +54,7 @@ to_field 'dlme_source_file', path_to_file
 
 # CHO Required
 to_field 'id', normalize_prefixed_id('id')
-to_field 'cho_title', json_title_or('name', 'expanded_name'), lang('fr')
+to_field 'cho_title', title_or('name', 'expanded_name'), lang('fr')
 
 # CHO Other
 to_field 'cho_date', lausanne_date_string, lang('en')

--- a/traject_configs/met.rb
+++ b/traject_configs/met.rb
@@ -54,7 +54,7 @@ to_field 'dlme_source_file', path_to_file
 to_field 'id', extract_json('.objectID'), lambda { |_record, accumulator, context|
   accumulator.map! { |bare_id| identifier_with_prefix(context, bare_id.to_s) }
 }
-to_field 'cho_title', json_title_plus('title', 'dimensions'), squish, lang('en')
+to_field 'cho_title', title_plus('title', 'dimensions'), squish, lang('en')
 
 # CHO Other
 to_field 'cho_coverage', extract_json('.culture'), transform(&:presence), lang('en')

--- a/traject_configs/penn_museum.rb
+++ b/traject_configs/penn_museum.rb
@@ -13,6 +13,7 @@ require 'macros/normalize_type'
 require 'macros/path_to_file'
 require 'macros/prepend'
 require 'macros/timestamp'
+require 'macros/title_extraction'
 require 'macros/transformation'
 require 'macros/version'
 require 'traject_plus'
@@ -28,6 +29,7 @@ extend Macros::NormalizeType
 extend Macros::PathToFile
 extend Macros::Prepend
 extend Macros::Timestamp
+extend Macros::TitleExtraction
 extend Macros::Transformation
 extend Macros::Version
 extend TrajectPlus::Macros
@@ -54,17 +56,14 @@ to_field 'dlme_source_file', path_to_file
 
 # CHO Required
 to_field 'id', extract_json('emuIRN'), flatten_array, transform(&:to_s), dlme_prepend('penn-museum-')
-to_field 'cho_title', extract_json('.title'), flatten_array, dlme_default('Untitled'), lang('en')
-to_field 'cho_title', extract_json('.objectName'), flatten_array, dlme_default('Untitled'), lang('en')
+to_field 'cho_title', title_plus_default('.title', '.objectName', 'Untitled'), flatten_array, lang('en')
 
 # CHO Other
 to_field 'cho_coverage', extract_json('.culture'), flatten_array, dlme_split('|'), lang('en')
 to_field 'cho_creator', extract_json('.creator'), flatten_array, lang('en')
 to_field 'cho_date', extract_json('.dateMade'), transform(&:to_s), flatten_array, lang('en')
-to_field 'cho_date', extract_json('.earlyDate'), transform(&:to_s), flatten_array, lang('en')
-to_field 'cho_date', extract_json('.lateDate'), transform(&:to_s), flatten_array, lang('en')
-to_field 'cho_date_range_norm', csv_or_json_date_range('date_made_early', 'date_made_late')
-to_field 'cho_date_range_hijri', csv_or_json_date_range('date_made_early', 'date_made_late'), hijri_range
+to_field 'cho_date_range_norm', csv_or_json_date_range('earlyDate', 'lateDate')
+to_field 'cho_date_range_hijri', csv_or_json_date_range('earlyDate', 'lateDate'), hijri_range
 to_field 'cho_description', extract_json('.nativeName'), flatten_array, dlme_prepend('Native name: '), lang('en')
 to_field 'cho_description', extract_json('.description'), flatten_array, lang('en')
 to_field 'cho_description', extract_json('.technique'), flatten_array, dlme_split('|'), lang('en')
@@ -82,14 +81,14 @@ to_field 'cho_has_type', extract_json('.objectName'), flatten_array, normalize_h
 to_field 'cho_has_type', extract_json('.objectName'), flatten_array, normalize_has_type, translation_map('has_type_ar_from_en'), lang('ar-Arab')
 to_field 'cho_identifier', extract_json('.identifier'), transform(&:to_s), flatten_array
 to_field 'cho_identifier', extract_json('.emuIRN'), transform(&:to_s), flatten_array
-to_field 'cho_is_part_of', extract_json('.curatorialSection'), flatten_array, dlme_prepend('Curatorial section:'), lang('en')
+to_field 'cho_is_part_of', extract_json('.curatorialSection'), flatten_array, dlme_prepend('Curatorial section: '), lang('en')
 to_field 'cho_language', extract_json('.inscriptionMarkLanguage'), flatten_array, dlme_split(','), dlme_split(';'), dlme_gsub('?', ''), normalize_language, lang('en')
 to_field 'cho_language', extract_json('.inscriptionMarkLanguage'), flatten_array, dlme_split(','), dlme_split(';'), dlme_gsub('?', ''), normalize_language, translation_map('lang_ar_from_en'), lang('ar-Arab')
 to_field 'cho_medium', extract_json('.material'), dlme_split('|'), flatten_array, lang('en')
 to_field 'cho_provenance', extract_json('.creditLine'), flatten_array, lang('en')
-to_field 'cho_spatial', extract_json('.locus'), flatten_array, dlme_prepend('Locus: '), lang('en')
 to_field 'cho_spatial', extract_json('.placeName'), flatten_array, dlme_split('|'), dlme_prepend('Place name: '), lang('en')
 to_field 'cho_spatial', extract_json('.siteName'), flatten_array, dlme_split('|'), dlme_prepend('Site name: '), lang('en')
+to_field 'cho_spatial', extract_json('.locus'), flatten_array, dlme_prepend('Locus: '), lang('en')
 to_field 'cho_subject', extract_json('.iconography'), flatten_array, lang('en')
 to_field 'cho_subject', extract_json('.iconographySubject'), flatten_array, lang('en')
 to_field 'cho_subject', extract_json('.cultureArea'), flatten_array, lang('en')


### PR DESCRIPTION
…xml title extraction macros. closes https://github.com/sul-dlss/dlme-transform/issues/1176

## Why was this change made?

Loaded Penn Museum records and noticed a few things that needed adjusting. I'm only keeping the Harvard SCW in xml form as notes of how I was mapping in the past. As soon as SCW harvest is working, I shift it over to using `extract_json`

## How was this change tested?

Local transform

## Which documentation and/or configurations were updated?

n/a

