### PR TITLE
Remove explicit dependency on mutex_m

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'dry-validation'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'ffi'
-gem 'mutex_m'
 gem 'parse_date'
 gem 'rake'
 gem 'thor' # for CLI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,14 +215,16 @@ GEM
     stringio (3.1.2)
     thor (1.3.2)
     thread_safe (0.3.6)
-    traject (3.8.2)
+    traject (3.8.3)
       concurrent-ruby (>= 0.8.0)
+      csv
       dot-properties (>= 0.1.1)
       hashie (>= 3.1, < 6)
       http (>= 3.0, < 6)
       httpclient (~> 2.5)
       marc (~> 1.0)
       marc-fastxmlwriter (~> 1.0)
+      mutex_m
       nokogiri (~> 1.9)
       slop (~> 4.0)
       yell
@@ -257,7 +259,6 @@ DEPENDENCIES
   faraday
   faraday_middleware
   ffi
-  mutex_m
   parse_date
   rake
   rspec


### PR DESCRIPTION
# Why was this change made?

Let traject deal with it on behalf of httpclient. It's not a direct dependency so let's not manage it.

# How was this change tested?

CI
