### PR TITLE
Add system dependencies required for recent gem updates in ffi and psych

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /opt/traject/output
 
 WORKDIR /opt/traject
 
-ENV BUNDLER_VERSION 2.5.22
+ENV BUNDLER_VERSION=2.6.5
 
 RUN apk add --no-cache \
     curl \
@@ -13,6 +13,8 @@ RUN apk add --no-cache \
     python3 \
     libxml2-dev \
     libxslt-dev \
+    yaml-dev \
+    linux-headers \
     jq \
     util-linux \
     && apk add --no-cache --virtual build-dependencies \
@@ -34,10 +36,6 @@ RUN bundle config build.nokogiri --use-system-libraries && \
     apk del build-dependencies
 
 COPY . /opt/traject/
-
-ENV SKIP_FETCH_DATA false
-ENV S3_BASE_URL https://s3-us-west-2.amazonaws.com
-ENV AWS_DEFAULT_REGION us-west-2
 
 # Metadata params
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ The traject configuration file used for a particular transform is triggered by
 the specified data directory. See "Configuring transforms" below.
 
 ```shell
-docker run --rm -e SKIP_FETCH_DATA=true \
-                -v $(pwd)/.:/opt/traject \
+docker run --rm -v $(pwd)/.:/opt/traject \
                 -v $(pwd)/../dlme-metadata:/opt/airflow/working \
                 -v $(pwd)/output:/opt/traject/output \
                 -v $(pwd)/output:/opt/airflow/metadata \
@@ -98,8 +97,7 @@ docker run --rm -v $(pwd)/output:/opt/traject/output \
 The `-w` switch can be used to debug transformations. It will stop the transform upon encountering an error.
 
 ```shell
-docker run --rm -e SKIP_FETCH_DATA=true \
-                -v $(pwd)/.:/opt/traject \
+docker run --rm -v $(pwd)/.:/opt/traject \
                 -v $(pwd)/../dlme-metadata:/opt/airflow/working \
                 -v $(pwd)/output:/opt/traject/output \
                 -v $(pwd)/output:/opt/airflow/metadata \


### PR DESCRIPTION
## Why was this change made?

This fixes the docker build that was failing due to missing system libraries needed by transient gems `ffi` and `psych`.

## How was this change tested?



## Which documentation and/or configurations were updated?



