### PR TITLE
Update bundler commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN apk add --no-cache \
 COPY Gemfile /opt/traject/
 COPY Gemfile.lock /opt/traject/
 
-RUN bundle config build.nokogiri --use-system-libraries && \
-    bundle install --without test && \
+RUN bundle config set build.nokogiri --use-system-libraries && \
+    bundle config set without test && \
     apk del build-dependencies
 
 COPY . /opt/traject/


### PR DESCRIPTION
## Why was this change made?

I noticed that the Docker image building hasn't been working since January 7?

https://app.circleci.com/pipelines/github/sul-dlss/dlme-transform/2770/workflows/3e1cef15-a6ce-4bcf-a62a-4cf34a1d77d6/jobs/4456

```
-dependencies:
#5 0.207 [DEPRECATED] Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set build.nokogiri --use-system-libraries` instead.
#5 0.324 The `--without` flag has been removed because it relied on being remembered
#5 0.324 across bundler invocations, which bundler no longer does. Instead please use
#5 0.324 `bundle config set without '****'`, and stop using this flag
```

It's easy to miss since it only runs when merging to main, not as part of update-dependencies testing.

This small change to how bundler is invoked seems to help.

## How was this change tested?

I saw `docker build .` fail before, and work after the change.

## Which documentation and/or configurations were updated?

n/a

